### PR TITLE
[#63] feat : JSON 역직렬화 예외 & 유효성 검증 예외처리

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,5 +35,6 @@ build/
 ### Mac OS ###
 .DS_Store
 
-*.properties
-*.yml
+src/main/resources/db.properties
+src/main/resources/s3.properties
+src/main/resources/application.yml

--- a/.idea/encodings.xml
+++ b/.idea/encodings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
-  <component name="Encoding">
+  <component name="Encoding" defaultCharsetForPropertiesFiles="UTF-8">
     <file url="file://$PROJECT_DIR$/src/main/java" charset="UTF-8" />
     <file url="file://$PROJECT_DIR$/src/main/resources" charset="UTF-8" />
   </component>

--- a/pom.xml
+++ b/pom.xml
@@ -193,6 +193,12 @@
       <version>5.8.7</version>
     </dependency>
 
+    <dependency>
+      <groupId>org.hibernate.validator</groupId>
+      <artifactId>hibernate-validator</artifactId>
+      <version>6.2.0.Final</version>
+    </dependency>
+
   </dependencies>
   <build>
     <finalName>AirBnG</finalName>

--- a/src/main/java/com/airbng/common/exception_handler/FieldValidationControllerAdvice.java
+++ b/src/main/java/com/airbng/common/exception_handler/FieldValidationControllerAdvice.java
@@ -11,11 +11,13 @@ import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 
 import java.util.List;
 import java.util.stream.Collectors;
 
 import static com.airbng.common.response.status.BaseResponseStatus.INVALID_FIELD;
+import static com.airbng.common.response.status.BaseResponseStatus.INVALID_PARAMETER;
 
 @Slf4j
 @RestControllerAdvice(annotations = RestController.class)
@@ -40,6 +42,23 @@ public class FieldValidationControllerAdvice {
         return ResponseEntity
                 .status(INVALID_FIELD.getHttpStatus())
                 .body(new BaseResponse(INVALID_FIELD, build));
+    }
+
+    /** 바인딩 전에 발생하는 예외<br>
+     * -> 예외 자체는 validation 전에 발생*/
+    @ExceptionHandler(MethodArgumentTypeMismatchException.class)
+    public ResponseEntity<BaseErrorResponse>  handleTypeMismatchException(MethodArgumentTypeMismatchException ex) {
+        log.info("[FieldValidationControllerAdvice] MethodArgumentTypeMismatchException");
+
+        FieldValidationError build = FieldValidationError.builder()
+                .fieldName(ex.getName())
+                .rejectValue((String) ex.getValue())
+                .message(ex.getMessage())
+                .build();
+
+        return ResponseEntity
+                .status(INVALID_PARAMETER.getHttpStatus())
+                .body(new BaseErrorResponse(INVALID_PARAMETER, build));
     }
 
 }

--- a/src/main/java/com/airbng/common/exception_handler/FieldValidationControllerAdvice.java
+++ b/src/main/java/com/airbng/common/exception_handler/FieldValidationControllerAdvice.java
@@ -1,0 +1,45 @@
+package com.airbng.common.exception_handler;
+
+import com.airbng.common.response.BaseErrorResponse;
+import com.airbng.common.response.BaseResponse;
+import com.airbng.common.response.FieldErrors;
+import com.airbng.common.response.FieldValidationError;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static com.airbng.common.response.status.BaseResponseStatus.INVALID_FIELD;
+
+@Slf4j
+@RestControllerAdvice(annotations = RestController.class)
+public class FieldValidationControllerAdvice {
+
+    /** 바인딩 후 발생하는 유효성 검증 예외 */
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<BaseResponse> handleMethodArgumentNotValidException(MethodArgumentNotValidException ex) {
+        log.info("[FieldValidationControllerAdvice] MethodArgumentNotValidException");
+
+        List<FieldError> fieldErrors = ex.getBindingResult().getFieldErrors();
+
+        FieldErrors build = FieldErrors.builder().errors(
+                        fieldErrors.stream().map(fieldError ->
+                                new FieldValidationError(
+                                        fieldError.getField(),
+                                        String.valueOf(fieldError.getRejectedValue()),
+                                        fieldError.getDefaultMessage())
+                        ).collect(Collectors.toList()))
+                .build();
+
+        return ResponseEntity
+                .status(INVALID_FIELD.getHttpStatus())
+                .body(new BaseResponse(INVALID_FIELD, build));
+    }
+
+}

--- a/src/main/java/com/airbng/common/exception_handler/GlobalExceptionControllerAdvice.java
+++ b/src/main/java/com/airbng/common/exception_handler/GlobalExceptionControllerAdvice.java
@@ -1,29 +1,36 @@
 package com.airbng.common.exception_handler;
 
 import com.airbng.common.exception.DomainException;
-import com.airbng.common.exception.ImageException;
 import com.airbng.common.response.BaseErrorResponse;
-import com.airbng.common.response.status.BaseResponseStatus;
-import org.springframework.http.HttpStatus;
+import com.airbng.common.response.FieldValidationError;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
-import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import java.time.format.DateTimeParseException;
+
+import static com.airbng.common.response.status.BaseResponseStatus.INVALID_DATETIME_FORMAT;
 
 @RestControllerAdvice
 public class GlobalExceptionControllerAdvice {
 
     @ExceptionHandler(DomainException.class)
-    public ResponseEntity<BaseErrorResponse> handle(DomainException ex) {
+    public ResponseEntity<BaseErrorResponse> handleDomainException(DomainException ex) {
         return ResponseEntity
                 .status(ex.getBaseResponseStatus().getHttpStatus())
                 .body(new BaseErrorResponse(ex.getBaseResponseStatus(), ex.getMessage()));
     }
 
-    @ExceptionHandler(IllegalArgumentException.class)
-    public ResponseEntity<BaseErrorResponse> handle(IllegalArgumentException ex) {
+    @ExceptionHandler(DateTimeParseException.class)
+    public ResponseEntity<BaseErrorResponse> handleDateTimeParseException(DateTimeParseException ex) {
+        FieldValidationError error = FieldValidationError.builder()
+                .fieldName("dateTime")
+                .rejectValue(ex.getParsedString())
+                .message(ex.getMessage())
+                .build();
+
         return ResponseEntity
-                .status(HttpStatus.BAD_REQUEST)
-                .body(new BaseErrorResponse(BaseResponseStatus.FAILURE, ex.getMessage()));
+                .status(INVALID_DATETIME_FORMAT.getHttpStatus())
+                .body(new BaseErrorResponse(INVALID_DATETIME_FORMAT, error));
     }
 }

--- a/src/main/java/com/airbng/common/exception_handler/JsonErrorControllerAdvice.java
+++ b/src/main/java/com/airbng/common/exception_handler/JsonErrorControllerAdvice.java
@@ -1,0 +1,92 @@
+package com.airbng.common.exception_handler;
+
+import com.airbng.common.response.BaseErrorResponse;
+import com.airbng.common.response.FieldValidationError;
+import com.airbng.common.response.JsonSyntaxError;
+import com.fasterxml.jackson.core.JsonParseException;
+import com.fasterxml.jackson.databind.exc.InvalidFormatException;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.util.ContentCachingRequestWrapper;
+
+import javax.servlet.http.HttpServletRequest;
+import java.io.UnsupportedEncodingException;
+
+import static com.airbng.common.response.status.BaseResponseStatus.INVALID_JSON_FORMAT;
+import static com.airbng.common.response.status.BaseResponseStatus.INVALID_JSON_SYNTAX;
+
+@Slf4j
+@RestControllerAdvice(annotations = RestController.class)
+public class JsonErrorControllerAdvice {
+
+    /** Json 역직렬화 오류 - Json 파싱 오류 */
+    @ExceptionHandler(JsonParseException.class)
+    public ResponseEntity<BaseErrorResponse> handleJsonParseError(JsonParseException ex, HttpServletRequest request) {
+        log.info("[JsonErrorControllerAdvice] JsonParseException: {}", ex.getMessage());
+        String requestBody = getRequestBody(request);
+        log.info("[JsonErrorControllerAdvice] Request Body: {}", requestBody);
+        JsonSyntaxError error = extractErrorLineFromJson(requestBody, ex);
+
+        return ResponseEntity
+                .status(INVALID_JSON_SYNTAX.getHttpStatus())
+                .body(new BaseErrorResponse(INVALID_JSON_SYNTAX, error));
+    }
+
+    /** Json 역직렬화 오류 - DTO 맵핑 실패 (타입 미스매치) */
+    @ExceptionHandler(InvalidFormatException.class)
+    public ResponseEntity<BaseErrorResponse> handleInvalidFormatException(InvalidFormatException ex) {
+        log.info("[JsonErrorControllerAdvice] InvalidFormatException: {}", ex.getMessage());
+
+        FieldValidationError error = FieldValidationError.builder()
+                .fieldName(extractFieldName(ex.getPath().toString()))
+                .rejectValue(ex.getValue().toString())
+                .message("JSON 역직렬화 오류 - " + ex.getTargetType().getTypeName() + " 형식이어야 합니다.")
+                .build();
+
+        return ResponseEntity
+                .status(INVALID_JSON_FORMAT.getHttpStatus())
+                .body(new BaseErrorResponse<>(INVALID_JSON_FORMAT, error));
+
+    }
+
+    private static String extractFieldName(String path) {
+        int startIndex = path.lastIndexOf("[\"");
+        int endIndex = path.lastIndexOf("\"]");
+        if (startIndex != -1 && endIndex != -1) {
+            return path.substring(startIndex + 2, endIndex);
+        }
+        return path;
+    }
+
+    private static String getRequestBody(HttpServletRequest request) {
+        if (request instanceof ContentCachingRequestWrapper) {
+            ContentCachingRequestWrapper wrapper = (ContentCachingRequestWrapper) request;
+            byte[] buf = wrapper.getContentAsByteArray();
+            if (buf.length > 0) {
+                try {
+                    return new String(buf, wrapper.getCharacterEncoding());
+                } catch (UnsupportedEncodingException e) {
+                    throw new RuntimeException(e);
+                }
+            }
+        }
+        return null;
+    }
+
+    public JsonSyntaxError extractErrorLineFromJson(String requestBody, JsonParseException ex) {
+        int errorLine = ex.getLocation().getLineNr();
+
+        String[] lines = requestBody.split("\r?\n");
+        String errorLineStr = lines[errorLine - 1];
+
+        return JsonSyntaxError.builder()
+                .lineNumber(errorLine)
+                .rejectValue(errorLineStr)
+                .message("JSON 문법 오류 - " + ex.getOriginalMessage())
+                .build();
+    }
+
+}

--- a/src/main/java/com/airbng/common/filter/CachingRequestFilter.java
+++ b/src/main/java/com/airbng/common/filter/CachingRequestFilter.java
@@ -1,0 +1,25 @@
+package com.airbng.common.filter;
+
+import org.springframework.web.util.ContentCachingRequestWrapper;
+
+import javax.servlet.*;
+import javax.servlet.http.HttpServletRequest;
+import java.io.IOException;
+
+/**
+ * 에러 로그를 남기기 위해 request를 캐싱해두는 필터<br>
+ * inputStream을 읽으면 request body가 소진되기 때문에<br>
+ * RequestWrapper를 사용하여 request body를 캐싱
+ */
+public class CachingRequestFilter implements Filter {
+
+    @Override
+    public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws IOException, ServletException {
+        if (request instanceof HttpServletRequest) {
+            ContentCachingRequestWrapper wrappedRequest = new ContentCachingRequestWrapper((HttpServletRequest) request);
+            chain.doFilter(wrappedRequest, response);
+        } else {
+            chain.doFilter(request, response);
+        }
+    }
+}

--- a/src/main/java/com/airbng/common/response/BaseErrorResponse.java
+++ b/src/main/java/com/airbng/common/response/BaseErrorResponse.java
@@ -3,14 +3,15 @@ package com.airbng.common.response;
 import com.airbng.common.response.status.ResponseStatus;
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import lombok.Getter;
 
 import java.time.LocalDateTime;
 
 @Getter
-@JsonPropertyOrder({"code", "message", "timestamp"})
-public class BaseErrorResponse implements ResponseStatus {
+@JsonPropertyOrder({"code", "message", "timestamp", "result"})
+public class BaseErrorResponse<T> implements ResponseStatus {
 
     private final int code;
     @JsonIgnore
@@ -19,16 +20,28 @@ public class BaseErrorResponse implements ResponseStatus {
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss")
     private final LocalDateTime timestamp;
 
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    private final T result;
+
     public BaseErrorResponse(ResponseStatus status) {
         this.code = status.getCode();
         this.message = status.getMessage();
         this.timestamp = LocalDateTime.now();
+        this.result = null;
     }
 
     public BaseErrorResponse(ResponseStatus status, String message) {
         this.code = status.getCode();
         this.message = message;
         this.timestamp = LocalDateTime.now();
+        this.result = null;
+    }
+
+    public BaseErrorResponse(ResponseStatus status, T result) {
+        this.code = status.getCode();
+        this.message = status.getMessage();
+        this.timestamp = LocalDateTime.now();
+        this.result = result;
     }
 
     @Override

--- a/src/main/java/com/airbng/common/response/FieldErrors.java
+++ b/src/main/java/com/airbng/common/response/FieldErrors.java
@@ -1,0 +1,14 @@
+package com.airbng.common.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@AllArgsConstructor
+@Getter
+@Builder
+public class FieldErrors {
+    List<FieldValidationError> errors;
+}

--- a/src/main/java/com/airbng/common/response/FieldValidationError.java
+++ b/src/main/java/com/airbng/common/response/FieldValidationError.java
@@ -1,0 +1,12 @@
+package com.airbng.common.response;
+
+import lombok.*;
+
+@AllArgsConstructor
+@Getter
+@Builder
+public class FieldValidationError {
+    private String fieldName;
+    private String rejectValue;
+    private String message;
+}

--- a/src/main/java/com/airbng/common/response/JsonSyntaxError.java
+++ b/src/main/java/com/airbng/common/response/JsonSyntaxError.java
@@ -1,0 +1,14 @@
+package com.airbng.common.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@AllArgsConstructor
+@Getter
+@Builder
+public class JsonSyntaxError {
+    private int lineNumber;
+    private String rejectValue;
+    private String message;
+}

--- a/src/main/java/com/airbng/common/response/status/BaseResponseStatus.java
+++ b/src/main/java/com/airbng/common/response/status/BaseResponseStatus.java
@@ -14,6 +14,7 @@ public enum BaseResponseStatus implements ResponseStatus{
     INVALID_FIELD(1002, HttpStatus.BAD_REQUEST.value(), "요청 본문에 잘못된 형식의 필드가 포함되어 있습니다."),
     INVALID_JSON_FORMAT(1003, HttpStatus.BAD_REQUEST.value(), "요청한 JSON 필드의 데이터 타입이 올바르지 않습니다."),
     INVALID_JSON_SYNTAX(1004, HttpStatus.BAD_REQUEST.value(), "요청 JSON의 문법이 올바르지 않습니다."),
+    INVALID_PARAMETER(1005, HttpStatus.BAD_REQUEST.value(), "요청한 파라미터 값이 타입에 맞지 않습니다."),
     INVALID_DATETIME_FORMAT(1006, HttpStatus.BAD_REQUEST.value(), "날짜 형식이 올바르지 않습니다. (yyyy-MM-dd HH:mm:ss)"),
 
     /**

--- a/src/main/java/com/airbng/common/response/status/BaseResponseStatus.java
+++ b/src/main/java/com/airbng/common/response/status/BaseResponseStatus.java
@@ -12,8 +12,8 @@ public enum BaseResponseStatus implements ResponseStatus{
     SUCCESS(1000,HttpStatus.OK.value(), "요청에 성공하였습니다."),
     FAILURE(1001, HttpStatus.BAD_REQUEST.value(), "요청에 실패하였습니다."),
     INVALID_FIELD(1002, HttpStatus.BAD_REQUEST.value(), "유효하지 않은 필드입니다."),
-    MALFORMED_JSON_FIELD(1003, HttpStatus.BAD_REQUEST.value(), "요청 본문에 잘못된 형식의 필드가 포함되어 있습니다."),
-    INVALID_JSON_EMPTY_FIELD(1004, HttpStatus.BAD_REQUEST.value(), "JSON 필드 타입 오류 - 필드의 값이 비어있거나 누락되었습니다."),
+    INVALID_JSON_FORMAT(1003, HttpStatus.BAD_REQUEST.value(), "요청한 JSON 필드의 데이터 타입이 올바르지 않습니다."),
+    INVALID_JSON_SYNTAX(1004, HttpStatus.BAD_REQUEST.value(), "요청 JSON의 문법이 올바르지 않습니다."),
     INVALID_DATETIME_FORMAT(1006, HttpStatus.BAD_REQUEST.value(), "날짜 형식이 올바르지 않습니다. (yyyy-MM-dd HH:mm:ss)"),
 
     /**

--- a/src/main/java/com/airbng/common/response/status/BaseResponseStatus.java
+++ b/src/main/java/com/airbng/common/response/status/BaseResponseStatus.java
@@ -14,6 +14,7 @@ public enum BaseResponseStatus implements ResponseStatus{
     INVALID_FIELD(1002, HttpStatus.BAD_REQUEST.value(), "유효하지 않은 필드입니다."),
     MALFORMED_JSON_FIELD(1003, HttpStatus.BAD_REQUEST.value(), "요청 본문에 잘못된 형식의 필드가 포함되어 있습니다."),
     INVALID_JSON_EMPTY_FIELD(1004, HttpStatus.BAD_REQUEST.value(), "JSON 필드 타입 오류 - 필드의 값이 비어있거나 누락되었습니다."),
+    INVALID_DATETIME_FORMAT(1006, HttpStatus.BAD_REQUEST.value(), "날짜 형식이 올바르지 않습니다. (yyyy-MM-dd HH:mm:ss)"),
 
     /**
      * 2000 맴버 관련 코드

--- a/src/main/java/com/airbng/common/response/status/BaseResponseStatus.java
+++ b/src/main/java/com/airbng/common/response/status/BaseResponseStatus.java
@@ -11,7 +11,7 @@ public enum BaseResponseStatus implements ResponseStatus{
      */
     SUCCESS(1000,HttpStatus.OK.value(), "요청에 성공하였습니다."),
     FAILURE(1001, HttpStatus.BAD_REQUEST.value(), "요청에 실패하였습니다."),
-    INVALID_FIELD(1002, HttpStatus.BAD_REQUEST.value(), "유효하지 않은 필드입니다."),
+    INVALID_FIELD(1002, HttpStatus.BAD_REQUEST.value(), "요청 본문에 잘못된 형식의 필드가 포함되어 있습니다."),
     INVALID_JSON_FORMAT(1003, HttpStatus.BAD_REQUEST.value(), "요청한 JSON 필드의 데이터 타입이 올바르지 않습니다."),
     INVALID_JSON_SYNTAX(1004, HttpStatus.BAD_REQUEST.value(), "요청 JSON의 문법이 올바르지 않습니다."),
     INVALID_DATETIME_FORMAT(1006, HttpStatus.BAD_REQUEST.value(), "날짜 형식이 올바르지 않습니다. (yyyy-MM-dd HH:mm:ss)"),

--- a/src/main/java/com/airbng/config/WebAppInitializer.java
+++ b/src/main/java/com/airbng/config/WebAppInitializer.java
@@ -1,0 +1,18 @@
+package com.airbng.config;
+
+import com.airbng.common.filter.CachingRequestFilter;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.WebApplicationInitializer;
+
+import javax.servlet.FilterRegistration;
+import javax.servlet.ServletContext;
+import javax.servlet.ServletException;
+
+@Configuration
+public class WebAppInitializer implements WebApplicationInitializer {
+    @Override
+    public void onStartup(ServletContext servletContext) {
+        FilterRegistration.Dynamic cachingFilter = servletContext.addFilter("cachingRequestFilter", new CachingRequestFilter());
+        cachingFilter.addMappingForUrlPatterns(null, false, "/*");
+    }
+}

--- a/src/main/java/com/airbng/controller/ReservationController.java
+++ b/src/main/java/com/airbng/controller/ReservationController.java
@@ -6,6 +6,8 @@ import com.airbng.service.ReservationService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 
+import javax.validation.Valid;
+
 @RestController
 @RequestMapping("/reservations")
 @RequiredArgsConstructor
@@ -13,7 +15,7 @@ public class ReservationController {
     private final ReservationService reservationService;
     // 예약 등록
     @PostMapping
-    public BaseResponse<String> insertReservation(@RequestBody ReservationInsertRequest request) {
+    public BaseResponse<String> insertReservation(@RequestBody @Valid ReservationInsertRequest request) {
         return new BaseResponse<>(reservationService.insertReservation(request));
     }
 

--- a/src/main/java/com/airbng/dto/reservation/ReservationInsertRequest.java
+++ b/src/main/java/com/airbng/dto/reservation/ReservationInsertRequest.java
@@ -4,6 +4,8 @@ import com.airbng.dto.jimType.JimTypeCountResult;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import lombok.*;
 
+import javax.validation.constraints.Min;
+import javax.validation.constraints.NotNull;
 import java.util.List;
 
 @Getter
@@ -14,10 +16,22 @@ import java.util.List;
 public class ReservationInsertRequest {
     @JsonIgnore
     private Long id;
+
+    @NotNull @Min(1)
     private Long dropperId; // 맡길 사람 ID
+    
+    @NotNull @Min(1)
     private Long keeperId;  // 맡길 짐을 보관하는 사람 ID
+
+    @NotNull @Min(1)
     private Long lockerId;  // 맡길 짐을 보관하는 락커 ID
+
+    @NotNull
     private String startTime; // 보관 시작 시간
+
+    @NotNull
     private String endTime;   // 회수해갈 시간
+
+    @NotNull
     private List<JimTypeCountResult> jimTypeCounts; // 맡길 짐 타입과 개수
 }

--- a/src/main/java/com/airbng/util/LocalDateTimeUtils.java
+++ b/src/main/java/com/airbng/util/LocalDateTimeUtils.java
@@ -7,12 +7,8 @@ import java.time.format.DateTimeParseException;
 public class LocalDateTimeUtils {
     private static final DateTimeFormatter FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
 
-    public static LocalDateTime parse(String dateTimeStr) {
-        try {
-            return LocalDateTime.parse(dateTimeStr, FORMATTER);
-        } catch (DateTimeParseException e) {
-            throw new IllegalArgumentException("올바르지 않은 날짜 형식입니다. 형식: yyyy-MM-dd HH:mm:ss", e);
-        }
+    public static LocalDateTime parse(String dateTimeStr) throws DateTimeParseException {
+        return LocalDateTime.parse(dateTimeStr, FORMATTER);
     }
 
     public static boolean isStartTimeAfterEndTime(String startTime, String endTime) {

--- a/src/main/resources/ValidationMessages.properties
+++ b/src/main/resources/ValidationMessages.properties
@@ -1,0 +1,1 @@
+javax.validation.constraints.NotNull.message=필수 입력값입니다.


### PR DESCRIPTION
# 요약 (Summary)
- JsonErrorControllerAdvice 구현
- FieldValidationControllerAdvice 구현
- GlobalExceptionControllerAdvice 수정

# 🔑 변경 사항 (Key Changes)
- JsonErrorControllerAdvice 에서 `JsonParseException`, `InvalidFormatException` 처리
- FieldValidationControllerAdvice 에서 `MethodArgumentTypeMismatchException`, `MethodArgumentNotValidException` 처리
  - BindingResult 활용하여 예외 리스트 반환
- GlobalExceptionControllerAdvice 에서 `DateTimeParseException` 처리
- Validation Default Message 설정 파일 추가 - `ValidationMessages.properties``
   - UTF-8 인코딩 처리 때문에 `.idea/encodings.xml` 파일 추가
- request body 캐싱을 위한 CachingRequestFilter 추가

# 예외 발생 흐름 설명
## JSON 역직렬화와 유효성 검증(Validation) 순서 요약
1️⃣ Json 형식의 Request가 오면
2️⃣ Jackson의 ObjectMapper가 역직렬화하여
3️⃣ DTO 인스턴스를 생성하고
4️⃣ @Valid 등의 어노테이션이 붙어있을 경우, 유효성 검증을 진행

⇒ 2️⃣ → 3️⃣ 역직렬화 과정에서 오류가 나면 3️⃣, 4️⃣는 애초에 동작도 안함
⇒ 모든 예외 처리해주어야 함

## 각 단계에서 터질 가능성이 있는 예외
### 2️⃣ - JSON 관련 예외 처리  `JsonErrorControllerAdvice`
- 발생 가능한 예외 : HttpMessageNotReadableException
  (JsonParseException | InvalidFormatException)

1. `JsonParseException` 처리
    JSON 문법 자체가 잘못되어 파싱이 불가한 경우
    - JSON 파싱이 실패하는 순간 뒷부분 확인 없이 예외가 터짐
    - 메시지에선 파싱 오류가 발생한 line, column 번호만 제공하기 때문에 어떤 필드에서 터진 예외인지 알 수 없음
       ![image](https://github.com/user-attachments/assets/2c7b3ff7-e013-4ea5-818b-935eaf156df9)
      ⇒ 어디서 터진 예외인지 제공하고 싶어서 RequestBody 에서 추출하고 싶은데, 가져올 수 없음
      ⇒ 왜?** inputStream을 읽으며 request body가 소진되기 때문.
           ⇒ request body 캐싱 필요!
              ⇒ `ContentCachingRequestWrapper`를 사용하여 request body를 캐싱
                   inputStream과 reader에서 읽은 모든 콘텐츠를 캐싱하고 바이트 배열을 통해 검색할 수 있게 해주는 `javax.servlet.http.HttpServletRequest` wrapper
                     **request와 lifecycle이 같고, 응답이 끝날 때 함께 GC 대상이 되므로 메모리 문제 x**
              ⇒ **`CachingRequestFilter` 구현**
      Handler 부분에선 `ContentCachingRequestWrapper` 를 이용하여 request body를 get해옴 
<table>
	<tr>
		<th>request body</th>
		<th>예시 사진</th>
	</tr>
	<tr>
		<td><pre><code>
{
  "dropperId": ""3,
  "endTime": "string",
  "jimTypeCounts": [
    {
      "count": 0,
      "jimTypeId": 0
    }
  ],
  "keeperId": "",
  "lockerId": "삼",
  "startTime": "string"
}
		</code></pre></td>
		<td>JsonParseException
			<image src="https://github.com/user-attachments/assets/8deefa7e-ea49-4b67-a94f-7ce7f5492ca2"/>
		</td>
	</tr>
</table>


2. `InvalidFormatException` 처리
JSON 문법은 지켰지만, 값의 타입이 DTO에서 기대한 타입과 일치하지 않을 경우
<table>
	<tr>
		<th>request body</th>
		<th>예시 사진</th>
	</tr>
	<tr>
		<td><pre><code>
{
  "dropperId": null,
  "endTime": "string",
  "jimTypeCounts": [
    {
      "count": 0,
      "jimTypeId": 0
    }
  ],
  "keeperId": "",
  "lockerId": "삼",
  "startTime": "string"
}
		</code></pre></td>
		<td>
			<image src="https://github.com/user-attachments/assets/23eb608b-bb85-43b0-97b1-fc8333305496"/>
		</td>
	</tr>
</table>


### 4️⃣ - 유효성 검증 예외 `FieldValidationControllerAdvice`
1. `MethodArgumentTypeMismatchException`
    - 바인딩 전에 발생하는 예외
    - `@RequstParam`, `@PathVariable` 등에 **잘못된 타입**의 값이 들어왔을 때 발생
    ![image](https://github.com/user-attachments/assets/b695bcf0-96be-44da-bf8c-edcdfa03862d)


2. `MethodArgumentNotValidException`
    - 바인딩 후 유효성 검증시 통과하지 못한 경우
    - 즉, DTO에서 기대하는 타입은 모두 맞지만 직접 지정한 유효성 조건(@NotNull 등)에 어긋났을 때
<table>
	<tr>
		<th>request body</th>
		<th>예시 사진</th>
	</tr>
	<tr>
		<td><pre><code>
{
  "dropperId": null,
  "endTime": "2025-06-03-13:00:00",
  "jimTypeCounts": [
    {
      "count": 0,
      "jimTypeId": 0
    }
  ],
  "keeperId": 0,
  "lockerId": "",
  "startTime": "2025-06-03 11:00:00"
}
		</code></pre></td>
		<td>
			<image src="https://github.com/user-attachments/assets/04d8e0b5-72e9-441d-8445-d1762e656565"/>
		</td>
	</tr>
</table>

<br><br>

# 📝 리뷰 요구사항 (To Reviewers)
- [ ] 각 Exception을 핸들링하는 ControllerAdvice 명이 적합한지 확인해주세요.
- [ ] 각 Exception이 적합한 ControllerAdvice 밑에서 핸들링 되는지 확인해주세요.
- [ ] 예외 메시지가 적합한지 확인해주세요.

# 확인 방법 
예외 발생 흐름 설명 에서 기재한 예시 사진을 참고해주세요.
