### PR TITLE
[#64] feat : BE 로그인 세션 도입

### DIFF
--- a/src/main/java/com/airbng/common/response/status/BaseResponseStatus.java
+++ b/src/main/java/com/airbng/common/response/status/BaseResponseStatus.java
@@ -20,6 +20,7 @@ public enum BaseResponseStatus implements ResponseStatus{
     /**
      * 2000 맴버 관련 코드
      */
+    SUCCESS_LOGIN(2000, HttpStatus.OK.value(), "로그인에 성공하였습니다."),
     NOT_FOUND_MEMBER(2001, HttpStatus.NOT_FOUND.value(), "존재하지 않는 멤버입니다."),
     DUPLICATE_EMAIL(2002,HttpStatus.BAD_REQUEST.value(), "중복이메일 사용"),
     DUPLICATE_NICKNAME(2003,HttpStatus.BAD_REQUEST.value(),"중복닉네임 사용"),
@@ -61,7 +62,12 @@ public enum BaseResponseStatus implements ResponseStatus{
     INVALID_EXTENSIONS(6003, HttpStatus.UNSUPPORTED_MEDIA_TYPE.value(),"허용되지 않는 파일 확장자입니다."),
     EXCEED_IMAGE_COUNT(6004, HttpStatus.PAYLOAD_TOO_LARGE.value(), "이미지 개수가 초과되었습니다. 최대 5개까지 업로드 가능합니다."),
 
-
+    /**
+     * 9000: sesssion
+     */
+    SESSION_NOT_FOUND(7000, HttpStatus.UNAUTHORIZED.value(), "세션이 존재하지 않습니다. 다시 로그인해주세요."),
+    SESSION_INVALID_TYPE(7001, HttpStatus.UNAUTHORIZED.value(), "세션 정보가 올바르지 않습니다."),
+    SESSION_EXPIRED(7002, HttpStatus.UNAUTHORIZED.value(), "세션이 만료되었습니다."),
 
     ;
 

--- a/src/main/java/com/airbng/controller/MemberController.java
+++ b/src/main/java/com/airbng/controller/MemberController.java
@@ -14,7 +14,10 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
+import javax.servlet.http.HttpSession;
+
 import static com.airbng.common.response.status.BaseResponseStatus.SUCCESS;
+import static com.airbng.common.response.status.BaseResponseStatus.SUCCESS_LOGIN;
 
 @RestController
 @RequestMapping("/members")
@@ -40,8 +43,18 @@ public class MemberController {
     }
 
     @PostMapping("/login")
-    public BaseResponse<MemberLoginResponse> login(@RequestBody MemberLoginRequest request) {
-        return new BaseResponse<>(memberService.login(request.getEmail(), request.getPassword()));
+    public BaseResponse<MemberLoginResponse> login(@RequestBody MemberLoginRequest request,
+                                                   HttpSession session) {
+        log.info("로그인 요청: email={}, password={}", request.getEmail(), request.getPassword());
+
+        MemberLoginResponse response = memberService.login(request.getEmail(), request.getPassword());
+
+        log.info("로그인 결과: {}", response);
+
+        // 세션에 memberId 저장
+        session.setAttribute("memberId", response.getMemberId());
+
+        return new BaseResponse<>(SUCCESS_LOGIN, response);
     }
 
 }

--- a/src/main/java/com/airbng/util/SessionUtils.java
+++ b/src/main/java/com/airbng/util/SessionUtils.java
@@ -1,0 +1,46 @@
+package com.airbng.util;
+
+import com.airbng.common.exception.MemberException;
+import com.airbng.common.response.status.BaseResponseStatus;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpSession;
+
+import static com.airbng.common.response.status.BaseResponseStatus.*;
+
+public class SessionUtils {
+
+    /**
+     * 세션에서 memberId를 꺼낸다. 없으면 null 반환
+     */
+    public static Long getMemberId(HttpServletRequest request) {
+        HttpSession session = request.getSession(false);
+        if (session == null) return null;
+
+        Object value = session.getAttribute("memberId");
+        return (value instanceof Long) ? (Long) value : null;
+    }
+
+    /**
+     * 로그인 여부 판단
+     */
+    public static boolean isLoggedIn(HttpServletRequest request) {
+        return getMemberId(request) != null;
+    }
+
+    public static Long getLoginMemberId(HttpSession session) {
+        if (session == null) {
+            throw new MemberException(SESSION_NOT_FOUND);
+        }
+
+        Object memberId = session.getAttribute("memberId");
+        if (memberId == null) {
+            throw new MemberException(SESSION_NOT_FOUND);
+        }
+
+        if (!(memberId instanceof Long)) {
+            throw new MemberException(SESSION_INVALID_TYPE);
+        }
+        return (Long) memberId;
+    }
+}

--- a/src/test/java/com/airbng/service/MemberServiceTest.java
+++ b/src/test/java/com/airbng/service/MemberServiceTest.java
@@ -14,6 +14,7 @@ import org.mockito.ArgumentMatchers;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mock.web.MockHttpSession;
 import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.web.multipart.MultipartFile;
@@ -259,5 +260,44 @@ class MemberServiceTest {
             assertEquals(INVALID_EMAIL, exception.getBaseResponseStatus(), "실패한 이메일: " + email);
         }
     }
+
+    @Test
+    @DisplayName("로그인 시 세션에 memberId 저장 확인")
+    void 로그인_세션_저장_확인() {
+        // given
+        String email = "valid@email.com";
+        String password = "Password1234!";
+
+        Member member = Member.builder()
+                .memberId(42L)
+                .email(email)
+                .name("재구")
+                .nickname("박재구")
+                .phone("010-1111-1111")
+                .password(password)
+                .status(BaseStatus.ACTIVE)
+                .profileImage(Image.withId(1L))
+                .build();
+
+        when(memberMapper.findByEmailAndPassword(email, password)).thenReturn(member);
+
+        // when
+        MemberLoginResponse response = memberService.login(email, password);
+
+        // 세션 객체 생성 및 저장 확인
+        MockHttpSession session = new MockHttpSession();
+        session.setAttribute("memberId", response.getMemberId());
+
+        Object sessionMemberId = session.getAttribute("memberId");
+        
+        // 콘솔 출력
+        System.out.println("세션에 저장된 memberId: " + sessionMemberId);
+
+        // then
+        assertEquals(42L, session.getAttribute("memberId"));
+        assertEquals(email, response.getEmail());
+        assertEquals("박재구", response.getNickname());
+    }
+
 
 }


### PR DESCRIPTION
## 요약 (Summary)
- [x] 로그인 시 memberId를 session에 저장 

## 🔑 변경 사항 (Key Changes)

- SessionUtils 클래스 작성
- MemberController > login > session 저장
- BaseResponse > Session 관련 9000번대로 추가
- MemberServiceTest에 로그인_세션_저장_확인 추가

## 📝 리뷰 요구사항 (To Reviewers)

- [ ] 로그인 시 Cookies에 JSESSIONID 잘 저장되는지!
- [ ] MemberServiceTest에 로그인_세션_저장_확인 잘 되는지!

## 확인 방법 

### 무조건 Postman으로 해야함
![image](https://github.com/user-attachments/assets/48c1299b-1de0-4558-8fcc-f681e223cc18)
Body - raw - DB에 저장되어 있는 email&password 작성

성공 시
![image](https://github.com/user-attachments/assets/caeb06b4-df98-45f1-a226-9a4073f35a3c)
![image](https://github.com/user-attachments/assets/7b3cf146-4cbf-4f5d-b10d-18d7d88d04d3)