### PR TITLE
[#43] feat : 닉네임 중복체크 API 개발

### DIFF
--- a/src/main/java/com/airbng/controller/MemberController.java
+++ b/src/main/java/com/airbng/controller/MemberController.java
@@ -41,6 +41,12 @@ public class MemberController {
         return new BaseResponse<>("사용 가능한 이메일");
     }
 
+    @GetMapping("/check-nickname")
+    public BaseResponse<String> nicknameCheck(@RequestParam String nickname) {
+        memberService.nicknameCheck(nickname);
+        return new BaseResponse<>("사용 가능한 닉네임");
+    }
+
     @GetMapping
     public BaseResponse<MemberMyPageResponse> findUserById(
             @RequestParam @NotNull @Min(1) Long memberId

--- a/src/main/java/com/airbng/service/MemberService.java
+++ b/src/main/java/com/airbng/service/MemberService.java
@@ -12,4 +12,5 @@ public interface MemberService {
     MemberMyPageResponse findUserById(Long memberId);
     MemberLoginResponse login(String email, String password);
     void emailCheck(String email);
+    void nicknameCheck(String nickname);
 }

--- a/src/main/java/com/airbng/service/MemberServiceImpl.java
+++ b/src/main/java/com/airbng/service/MemberServiceImpl.java
@@ -70,6 +70,11 @@ public class MemberServiceImpl implements MemberService {
     }
 
     @Override
+    public void nicknameCheck(String nickname) {
+        if (memberMapper.findByNickname(nickname))          throw new MemberException(DUPLICATE_NICKNAME);
+    }
+
+    @Override
     public MemberMyPageResponse findUserById(Long memberId) {
         //Long memberId = request.getMemberId();
 


### PR DESCRIPTION
## 요약 (Summary)
- [x] 닉네임 중복체크 API 개발입니다.

## 🔑 변경 사항 (Key Changes)

- `MemberController` : 닉네임 체크 매핑 작성
- `MemberService` : 닉네임 체크 메서드 선언
- `MemberServiceImpl` : 닉네임 체크 메서드 구현
- `MemberMapper.java, xml` : 기존 회원가입시에 작성했던 닉네임 중복 검사 사용

## 📝 리뷰 요구사항 (To Reviewers)

- [x] 정상적으로 닉네임 중복검사가 진행되는지 테스트 해주세요

## 확인 방법 
url : http://localhost:8080/AirBnG/swagger-ui.html#/member-controller/nicknameCheckUsingGET
