### PR TITLE
[#16] feat : 예약 승인 거절 api 개발

### DIFF
--- a/src/main/java/com/airbng/common/response/status/BaseResponseStatus.java
+++ b/src/main/java/com/airbng/common/response/status/BaseResponseStatus.java
@@ -49,6 +49,8 @@ public enum BaseResponseStatus implements ResponseStatus{
     INVALID_RESERVATION_TIME_ORDER(4005, HttpStatus.BAD_REQUEST.value(), "시작 시간은 종료 시간보다 작아야합니다."),
     CANNOT_UPDATE_STATE(4006,HttpStatus.BAD_REQUEST.value(), "예약 상태 변경에 실패하였습니다."),
     NOT_DROPPER_OF_RESERVATION(4007,HttpStatus.BAD_REQUEST.value(), "해당 예약의 짐을 맡긴 사람이 아닙니다."),
+    NOT_KEEPER_OF_RESERVATION(4008,HttpStatus.BAD_REQUEST.value(), "해당 예약의 담당자가 아닙니다."),
+    ALREADY_CANCELLED_RESERVATION(4009, HttpStatus.BAD_REQUEST.value(), "이미 취소된 예약입니다."),
 
 
     /**

--- a/src/main/java/com/airbng/controller/ReservationController.java
+++ b/src/main/java/com/airbng/controller/ReservationController.java
@@ -2,16 +2,14 @@ package com.airbng.controller;
 
 import com.airbng.common.response.BaseResponse;
 import com.airbng.domain.base.ReservationState;
-import com.airbng.dto.reservation.ReservationCancelResponse;
-import com.airbng.dto.reservation.ReservationDetailResponse;
-import com.airbng.dto.reservation.ReservationInsertRequest;
-import com.airbng.dto.reservation.ReservationPaging;
+import com.airbng.dto.reservation.*;
 import com.airbng.service.ReservationService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.validation.annotation.Validated;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
+
+import javax.servlet.http.HttpSession;
 import javax.validation.Valid;
 import javax.validation.constraints.Min;
 import javax.validation.constraints.NotNull;
@@ -23,6 +21,15 @@ import javax.validation.constraints.NotNull;
 @Slf4j
 public class ReservationController {
     private final ReservationService reservationService;
+
+    //예약 승인 취소
+    @PatchMapping("/{reservation-id}/members/{member-id}/confirm")
+    public BaseResponse<ReservationConfirmResponse> confirmResponse(
+            @PathVariable("reservation-id") @NotNull @Min(1) Long reservationId,
+            @PathVariable("member-id") Long memberId,
+            @RequestParam("approve") String approve) {
+        return new BaseResponse<>(reservationService.confirmReservationState(reservationId, approve, memberId));
+    }
 
     @PostMapping("/{reservation-id}/members/{member-id}/cancel")
     public BaseResponse<ReservationCancelResponse> updateResponse(@PathVariable("reservation-id") Long reservationId, @PathVariable("member-id") Long memberId) {

--- a/src/main/java/com/airbng/dto/reservation/ReservationConfirmResponse.java
+++ b/src/main/java/com/airbng/dto/reservation/ReservationConfirmResponse.java
@@ -1,0 +1,26 @@
+package com.airbng.dto.reservation;
+
+import com.airbng.domain.Reservation;
+import com.airbng.domain.base.ReservationState;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class ReservationConfirmResponse {
+    private Long reservationId;
+    private ReservationState state;
+
+    public static ReservationConfirmResponse of(Reservation reservation, ReservationState newState) {
+        return ReservationConfirmResponse.builder()
+                .reservationId(reservation.getReservationId())
+                .state(newState)
+                .build();
+    }
+}

--- a/src/main/java/com/airbng/mappers/ReservationMapper.java
+++ b/src/main/java/com/airbng/mappers/ReservationMapper.java
@@ -15,10 +15,10 @@ public interface ReservationMapper {
 
     void updateReservationState(@Param("reservationId")Long reservationId, @Param("state")ReservationState state);
     Reservation findReservationWithDropperById(Long reservationId);
-  
+    Reservation findReservationWithKeeperById(Long reservationId);
+
     void insertReservation(ReservationInsertRequest reservation);
     Reservation findReservationDetailById(@Param("reservationId") Long reservationId);
-
     // 예약 조회 + 페이징 처리
     List<ReservationSearchResponse> findAllReservationById(
                                              @Param("memberId") Long memberId,
@@ -27,7 +27,6 @@ public interface ReservationMapper {
                                              @Param("nextCursorId") Long nextCursorId,
                                              @Param("limit") Long limit
     );
-
     //예약  목록 개수
     Long findReservationByMemberId(@Param("memberId") Long memberId, @Param("role") String role);
 }

--- a/src/main/java/com/airbng/service/ReservationService.java
+++ b/src/main/java/com/airbng/service/ReservationService.java
@@ -1,12 +1,9 @@
 package com.airbng.service;
 
 import com.airbng.common.response.status.BaseResponseStatus;
-import com.airbng.dto.reservation.ReservationDetailResponse;
+import com.airbng.dto.reservation.*;
 import com.airbng.domain.base.ReservationState;
-import com.airbng.dto.reservation.ReservationInsertRequest;
-import com.airbng.dto.reservation.ReservationPaging;
 import org.springframework.stereotype.Service;
-import com.airbng.dto.reservation.ReservationCancelResponse;
 
 @Service
 public interface ReservationService {
@@ -18,6 +15,9 @@ public interface ReservationService {
      * 예약 취소 기능
      * */
     public ReservationCancelResponse updateReservationState(Long reservationId, Long memberId);
+
+    //예약 승인/거절
+    ReservationConfirmResponse confirmReservationState(Long reservationId, String approve, Long memberId);
 
     // 예약 등록
     BaseResponseStatus insertReservation(ReservationInsertRequest request);

--- a/src/main/java/com/airbng/service/ReservationServiceImpl.java
+++ b/src/main/java/com/airbng/service/ReservationServiceImpl.java
@@ -144,9 +144,6 @@ public class ReservationServiceImpl implements ReservationService{
             //짐을 맡아주는 사람인지 확인
             if (!reservation.getKeeper().getMemberId().equals(memberId)) throw new ReservationException(NOT_KEEPER_OF_RESERVATION);
 
-            //이미 취소된 예약인지 확인
-//            if (reservation.getState().equals(ReservationState.CANCELLED)) throw new ReservationException(ALREADY_CANCELLED_RESERVATION);
-
             //취소, 완료상태는 상태변경 불가
             reservation.getState().isAvailableUpdate(reservation.getState());
 

--- a/src/main/java/com/airbng/service/ReservationServiceImpl.java
+++ b/src/main/java/com/airbng/service/ReservationServiceImpl.java
@@ -145,7 +145,7 @@ public class ReservationServiceImpl implements ReservationService{
             if (!reservation.getKeeper().getMemberId().equals(memberId)) throw new ReservationException(NOT_KEEPER_OF_RESERVATION);
 
             //이미 취소된 예약인지 확인
-            if (reservation.getState().equals(ReservationState.CANCELLED)) throw new ReservationException(ALREADY_CANCELLED_RESERVATION);
+//            if (reservation.getState().equals(ReservationState.CANCELLED)) throw new ReservationException(ALREADY_CANCELLED_RESERVATION);
 
             //취소, 완료상태는 상태변경 불가
             reservation.getState().isAvailableUpdate(reservation.getState());

--- a/src/main/java/com/airbng/service/ReservationServiceImpl.java
+++ b/src/main/java/com/airbng/service/ReservationServiceImpl.java
@@ -8,13 +8,8 @@ import com.airbng.common.response.status.BaseResponseStatus;
 import com.airbng.domain.base.ReservationState;
 import com.airbng.domain.Reservation;
 import com.airbng.domain.base.ChargeType;
-import com.airbng.domain.base.ReservationState;
 import com.airbng.dto.jimType.JimTypeCountResult;
-import com.airbng.dto.reservation.ReservationCancelResponse;
-import com.airbng.dto.reservation.ReservationDetailResponse;
-import com.airbng.dto.reservation.ReservationInsertRequest;
-import com.airbng.dto.reservation.ReservationPaging;
-import com.airbng.dto.reservation.ReservationSearchResponse;
+import com.airbng.dto.reservation.*;
 import com.airbng.mappers.JimTypeMapper;
 import com.airbng.mappers.LockerMapper;
 import com.airbng.mappers.MemberMapper;
@@ -131,6 +126,47 @@ public class ReservationServiceImpl implements ReservationService{
                 lock.unlock();
             }
     }
+
+    @Override
+    @Transactional
+    public ReservationConfirmResponse confirmReservationState(Long reservationId, String approve, Long memberId) {
+        ReentrantLock lock = reservationLocks.get(reservationId, key -> new ReentrantLock());
+        try {
+            //락 걸어
+            lock.lock();
+            //멤버 존재 유무 파악
+            if (!memberMapper.findById(memberId)) throw new MemberException(NOT_FOUND_MEMBER);
+
+            //예약건의 존재 여부 파악
+            Reservation reservation = reservationMapper.findReservationWithKeeperById(reservationId);
+            if (reservation == null) throw new ReservationException(NOT_FOUND_RESERVATION);
+
+            //짐을 맡아주는 사람인지 확인
+            if (!reservation.getKeeper().getMemberId().equals(memberId)) throw new ReservationException(NOT_KEEPER_OF_RESERVATION);
+
+            //이미 취소된 예약인지 확인
+            if (reservation.getState().equals(ReservationState.CANCELLED)) throw new ReservationException(ALREADY_CANCELLED_RESERVATION);
+
+            //취소, 완료상태는 상태변경 불가
+            reservation.getState().isAvailableUpdate(reservation.getState());
+
+            //상태값 저장
+            ReservationState newState;
+            if ("yes".equalsIgnoreCase(approve)) {
+                newState = ReservationState.CONFIRMED;
+            } else if ("no".equalsIgnoreCase(approve)) {
+                newState = ReservationState.CANCELLED;
+            } else {
+                throw new ReservationException(CANNOT_UPDATE_STATE);
+            }
+            reservationMapper.updateReservationState(reservationId, newState);
+
+            return ReservationConfirmResponse.of(reservation, newState);
+        } finally {
+            lock.unlock();
+        }
+    }
+
     // 예약 등록
     @Override
     @Transactional // 짐타입 등록 실패한 경우 예약 등록까지 롤백

--- a/src/main/resources/mappers/ReservationMapper.xml
+++ b/src/main/resources/mappers/ReservationMapper.xml
@@ -188,4 +188,41 @@
         WHERE reservation_id = #{reservationId}
     </update>
 
+    <resultMap id="ReservationWithKeeperMap" type="com.airbng.domain.Reservation">
+        <result property="reservationId" column="reservation_id"/>
+        <result property="state" column="state"/>
+        <result property="startTime" column="start_time"/>
+        <result property="endTime" column="end_time"/>
+
+        <association property="keeper" javaType="com.airbng.domain.Member">
+            <result property="memberId" column="keeper_id"/>
+            <result property="email" column="keeper_email"/>
+            <result property="name" column="keeper_name"/>
+            <result property="phone" column="keeper_phone"/>
+            <result property="nickname" column="keeper_nickname"/>
+            <result property="password" column="keeper_password"/>
+            <result property="status" column="keeper_status"/>
+        </association>
+    </resultMap>
+
+    <select id="findReservationWithKeeperById" parameterType="Long" resultMap="ReservationWithKeeperMap">
+        SELECT
+            r.reservation_id,
+            r.state,
+            r.start_time,
+            r.end_time,
+
+            k.member_id AS keeper_id,
+            k.email AS keeper_email,
+            k.name AS keeper_name,
+            k.phone AS keeper_phone,
+            k.nickname AS keeper_nickname,
+            k.password AS keeper_password,
+            k.status AS keeper_status
+
+        FROM reservation r
+                 JOIN member k ON r.keeper_id = k.member_id
+        WHERE r.reservation_id = #{reservationId}
+    </select>
+
 </mapper>

--- a/src/test/java/com/airbng/service/ReservationConfirmServiceTest.java
+++ b/src/test/java/com/airbng/service/ReservationConfirmServiceTest.java
@@ -163,8 +163,8 @@ public class ReservationConfirmServiceTest {
                     reservationService.confirmReservationState(reservationId, approve, memberId));
 
             //then
-            assertEquals(ALREADY_CANCELLED_RESERVATION, exception.getBaseResponseStatus());
-            assertEquals(ALREADY_CANCELLED_RESERVATION.getMessage(), exception.getMessage());
+            assertEquals(CANNOT_UPDATE_STATE, exception.getBaseResponseStatus());
+            assertEquals(CANNOT_UPDATE_STATE.getMessage(), exception.getMessage());
         }
     }
 }

--- a/src/test/java/com/airbng/service/ReservationConfirmServiceTest.java
+++ b/src/test/java/com/airbng/service/ReservationConfirmServiceTest.java
@@ -1,0 +1,170 @@
+package com.airbng.service;
+
+import com.airbng.common.exception.ReservationException;
+import com.airbng.domain.Member;
+import com.airbng.domain.Reservation;
+import com.airbng.domain.base.BaseStatus;
+import com.airbng.domain.base.ReservationState;
+import com.airbng.domain.image.Image;
+import com.airbng.dto.reservation.ReservationConfirmResponse;
+import com.airbng.mappers.MemberMapper;
+import com.airbng.mappers.ReservationMapper;
+import com.github.benmanes.caffeine.cache.Cache;
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.locks.ReentrantLock;
+
+import static com.airbng.common.response.status.BaseResponseStatus.ALREADY_CANCELLED_RESERVATION;
+import static com.airbng.common.response.status.BaseResponseStatus.CANNOT_UPDATE_STATE;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+public class ReservationConfirmServiceTest {
+
+    @Mock
+    private ReservationMapper  reservationMapper;
+    @Mock
+    private MemberMapper memberMapper;
+
+    @Mock
+    private Cache<Long, ReentrantLock> reservationLocks;
+
+    Member dropper, keeper;
+
+    @InjectMocks
+    private ReservationServiceImpl reservationService;
+
+    @BeforeEach
+    void setUp() {
+        Image image = Image.builder()
+                .imageId(1L)
+                .url("https://example.com/images/profile")
+                .uploadName("profile")
+                .build();
+
+        dropper = Member.builder()
+                .memberId(1L)
+                .email("test@airbng.com")
+                .name("테스터")
+                .phone("010-0000-0000")
+                .nickname("testUser")
+                .password("encoded_test_password")
+                .status(BaseStatus.ACTIVE)
+                .profileImage(image)
+                .build();
+
+        keeper = Member.builder()
+                .memberId(2L)
+                .email("test@airbng.com")
+                .name("테스터")
+                .phone("010-0000-0000")
+                .nickname("testUser")
+                .password("encoded_test_password")
+                .status(BaseStatus.ACTIVE)
+                .profileImage(image)
+                .build();
+
+        when(reservationLocks.get(anyLong(), any())).thenAnswer(invocation -> new ReentrantLock());
+    }
+
+    @Nested
+    @DisplayName("요청 성공 테스트")
+    class SuccessTest {
+        @Test
+        @DisplayName("정상 케이스 - 예약상태를 CONFIRMED 변경")
+        void 예약_승인_성공() {
+
+            //given
+            Long reservationId = 1L;
+            Long memberId = keeper.getMemberId();
+            String approve = "yes";
+
+            Reservation reservation = Reservation.builder()
+                    .reservationId(reservationId)
+                    .dropper(dropper)
+                    .keeper(keeper)
+                    .startTime(LocalDateTime.now())
+                    .endTime(LocalDateTime.now().plusDays(1))
+                    .state(ReservationState.PENDING)
+                    .build();
+            when(memberMapper.findById(memberId)).thenReturn(true);
+            when(reservationMapper.findReservationWithKeeperById(reservationId)).thenReturn(reservation);
+
+            //when
+            ReservationConfirmResponse response = reservationService.confirmReservationState(reservationId, approve, memberId);
+
+            //then
+            assertEquals(ReservationState.CONFIRMED, response.getState());
+            verify(reservationMapper).updateReservationState(reservationId, ReservationState.CONFIRMED);
+        }
+
+        @Test
+        @DisplayName("정상 케이스 - 예약상태를 CANCELED 변경")
+        void 예약_거절_성공() {
+            //given
+            Long reservationId = 2L;
+            Long memberId = keeper.getMemberId();
+            String approve = "no";
+
+            Reservation reservation = Reservation.builder()
+                    .reservationId(reservationId)
+                    .dropper(dropper)
+                    .keeper(keeper)
+                    .startTime(LocalDateTime.now())
+                    .endTime(LocalDateTime.now().plusDays(1))
+                    .state(ReservationState.PENDING)
+                    .build();
+            when(memberMapper.findById(memberId)).thenReturn(true);
+            when(reservationMapper.findReservationWithKeeperById(reservationId)).thenReturn(reservation);
+
+            //when
+            ReservationConfirmResponse response = reservationService.confirmReservationState(reservationId, approve, memberId);
+
+            //then
+            assertEquals(ReservationState.CANCELLED, response.getState());
+            verify(reservationMapper).updateReservationState(reservationId, ReservationState.CANCELLED);
+        }
+    }
+
+    @Nested
+    @DisplayName("예외 처리 테스트")
+    class ExceptionTest {
+
+        @Test
+        @DisplayName("예약 상태가 이미 취소됨 (변경 불가)")
+        void 예약_상태가_완료됨() {
+            //given
+            Long reservationId = 3L;
+            Long memberId = keeper.getMemberId();
+            String approve = "yes";
+
+            Reservation reservation = Reservation.builder()
+                    .reservationId(reservationId)
+                    .dropper(dropper)
+                    .keeper(keeper)
+                    .startTime(LocalDateTime.now())
+                    .endTime(LocalDateTime.now().plusDays(1))
+                    .state(ReservationState.CANCELLED)
+                    .build();
+            when(memberMapper.findById(memberId)).thenReturn(true);
+            when(reservationMapper.findReservationWithKeeperById(reservationId)).thenReturn(reservation);
+
+            //when
+            ReservationException exception = assertThrows(ReservationException.class, () ->
+                    reservationService.confirmReservationState(reservationId, approve, memberId));
+
+            //then
+            assertEquals(ALREADY_CANCELLED_RESERVATION, exception.getBaseResponseStatus());
+            assertEquals(ALREADY_CANCELLED_RESERVATION.getMessage(), exception.getMessage());
+        }
+    }
+}


### PR DESCRIPTION
## 요약 (Summary)
- 예약 승인/거절 API 개발
- 이에 대한 테스트 작성 
  - ReservationConfirmServiceTest

## 🔑 변경 사항 (Key Changes)

- `confirmReservationState` 메서드에 ReentrantLock적용 -> 동일 예약건에 대해 중복 요청 발생시 동시성 문제 방지
- 예외 처리 케이스 명시
  - 존재하지 않는 맴버일 경우: `MemberException(NOT_FOUND_MEMBER)`
  - 존재하지 않는 예약일 경우: `ReservationException(NOT_FOUND_RESERVATION)`
  - 담당자와 요청자가 다를 경우: `ReservationException(NOT_KEEPER_OF_RESERVATION)`
  - 이미 취소/완료된 예약일 경우: `ReservationException(CANNOT_UPDATE_STATE)`
- 테스트 내역
  - 정상 케이스 - 예약 승인
  - 정상 케이스 - 예약 거절
  - 예외 케이스 - 이미 취소상태(CANCELED)일 경우 변경 불가 

## 📝 리뷰 요구사항 (To Reviewers)

- [x] 정상적으로 예약 승인/거절 되는지 테스트해주세요
- [x] 추가적으로 막아야 할 예외상황이 있는지 확인해주세요

## 확인 방법 
http://localhost:8080/AirBnG/swagger-ui.html#/reservation-controller/confirmResponseUsingPATCH
- 요청 성공시
  - 예약 승인
![image](https://github.com/user-attachments/assets/a27bf385-579e-4418-b94e-de82f4c8fc7c)

- 요청 예외
  - 담당자가 다를경우
![image](https://github.com/user-attachments/assets/326e1d24-6b9b-4d4f-ab43-65a75f1cfcb4)

  - 예약 상태가 완료 혹은 취소 상태일경우
![image](https://github.com/user-attachments/assets/f6d77c92-bf98-450e-86c0-9a01eb7be306)
