### PR TITLE
[#61] BE 보관소 찜기능 API 만들기

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -199,6 +199,31 @@
       <version>6.2.0.Final</version>
     </dependency>
 
+    <!-- redis -->
+    <dependency>
+      <groupId>org.springframework.data</groupId>
+      <artifactId>spring-data-redis</artifactId>
+      <version>2.7.18</version>
+    </dependency>
+
+    <dependency>
+      <groupId>io.lettuce</groupId>
+      <artifactId>lettuce-core</artifactId>
+      <version>6.2.6.RELEASE</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.springframework.session</groupId>
+      <artifactId>spring-session-data-redis</artifactId>
+      <version>2.5.3</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.json</groupId>
+      <artifactId>json</artifactId>
+      <version>20240303</version>
+    </dependency>
+
   </dependencies>
   <build>
     <finalName>AirBnG</finalName>

--- a/pom.xml
+++ b/pom.xml
@@ -73,12 +73,6 @@
 
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
-      <artifactId>jackson-databind</artifactId>
-      <version>2.15.3</version>
-    </dependency>
-
-    <dependency>
-      <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-core</artifactId>
       <version>2.15.3</version>
     </dependency>
@@ -222,6 +216,7 @@
       <groupId>org.json</groupId>
       <artifactId>json</artifactId>
       <version>20240303</version>
+    </dependency>
       
     <dependency>
         <groupId>com.github.ben-manes.caffeine</groupId>

--- a/src/main/java/com/airbng/common/exception/SessionException.java
+++ b/src/main/java/com/airbng/common/exception/SessionException.java
@@ -1,0 +1,16 @@
+package com.airbng.common.exception;
+
+import com.airbng.common.response.status.BaseResponseStatus;
+import lombok.Getter;
+
+@Getter
+public class SessionException extends DomainException {
+
+    public SessionException(BaseResponseStatus baseResponseStatus) {
+        super(baseResponseStatus);
+    }
+
+    public SessionException(BaseResponseStatus baseResponseStatus, String detailMessage) {
+        super(baseResponseStatus, detailMessage);
+    }
+}

--- a/src/main/java/com/airbng/common/exception/ZzimException.java
+++ b/src/main/java/com/airbng/common/exception/ZzimException.java
@@ -1,0 +1,16 @@
+package com.airbng.common.exception;
+
+import com.airbng.common.response.status.BaseResponseStatus;
+import lombok.Getter;
+
+@Getter
+public class ZzimException extends DomainException {
+
+    public ZzimException(BaseResponseStatus baseResponseStatus) {
+        super(baseResponseStatus);
+    }
+
+    public ZzimException(BaseResponseStatus baseResponseStatus, String detailMessage) {
+        super(baseResponseStatus, detailMessage);
+    }
+}

--- a/src/main/java/com/airbng/common/filter/CachedBodyHttpServletRequest.java
+++ b/src/main/java/com/airbng/common/filter/CachedBodyHttpServletRequest.java
@@ -1,0 +1,29 @@
+package com.airbng.common.filter;
+
+import javax.servlet.ServletInputStream;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletRequestWrapper;
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+
+public class CachedBodyHttpServletRequest extends HttpServletRequestWrapper {
+    private final byte[] cachedBody;
+
+    public CachedBodyHttpServletRequest(HttpServletRequest request) throws IOException {
+        super(request);
+        InputStream requestInputStream = request.getInputStream();
+        this.cachedBody = requestInputStream.readAllBytes();
+    }
+
+    @Override
+    public ServletInputStream getInputStream() {
+        return new CachedServletInputStream(this.cachedBody);
+    }
+
+    @Override
+    public BufferedReader getReader() {
+        return new BufferedReader(new InputStreamReader(getInputStream()));
+    }
+}

--- a/src/main/java/com/airbng/common/filter/CachedServletInputStream.java
+++ b/src/main/java/com/airbng/common/filter/CachedServletInputStream.java
@@ -1,0 +1,32 @@
+package com.airbng.common.filter;
+
+import javax.servlet.ReadListener;
+import javax.servlet.ServletInputStream;
+import java.io.ByteArrayInputStream;
+
+public class CachedServletInputStream extends ServletInputStream {
+    private final ByteArrayInputStream buffer;
+
+    public CachedServletInputStream(byte[] contents) {
+        this.buffer = new ByteArrayInputStream(contents);
+    }
+
+    @Override
+    public int read() {
+        return buffer.read();
+    }
+
+    @Override
+    public boolean isFinished() {
+        return buffer.available() == 0;
+    }
+
+    @Override
+    public boolean isReady() {
+        return true;
+    }
+
+    @Override
+    public void setReadListener(ReadListener listener) {}
+}
+

--- a/src/main/java/com/airbng/common/filter/CachingRequestFilter.java
+++ b/src/main/java/com/airbng/common/filter/CachingRequestFilter.java
@@ -1,7 +1,5 @@
 package com.airbng.common.filter;
 
-import org.springframework.core.annotation.Order;
-import org.springframework.stereotype.Component;
 import org.springframework.web.util.ContentCachingRequestWrapper;
 
 import javax.servlet.*;
@@ -13,19 +11,13 @@ import java.io.IOException;
  * inputStream을 읽으면 request body가 소진되기 때문에<br>
  * RequestWrapper를 사용하여 request body를 캐싱
  */
-@Component
-@Order(1)
 public class CachingRequestFilter implements Filter {
+
     @Override
-    public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain)
-            throws IOException, ServletException {
-
+    public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws IOException, ServletException {
         if (request instanceof HttpServletRequest) {
-            System.out.println("[Filter] CachedBodyHttpServletRequest 적용됨");
-
-            HttpServletRequest httpServletRequest = (HttpServletRequest) request;
-            CachedBodyHttpServletRequest cachedRequest = new CachedBodyHttpServletRequest(httpServletRequest);
-            chain.doFilter(cachedRequest, response);
+            ContentCachingRequestWrapper wrappedRequest = new ContentCachingRequestWrapper((HttpServletRequest) request);
+            chain.doFilter(wrappedRequest, response);
         } else {
             chain.doFilter(request, response);
         }

--- a/src/main/java/com/airbng/common/filter/CachingRequestFilter.java
+++ b/src/main/java/com/airbng/common/filter/CachingRequestFilter.java
@@ -1,5 +1,7 @@
 package com.airbng.common.filter;
 
+import org.springframework.core.annotation.Order;
+import org.springframework.stereotype.Component;
 import org.springframework.web.util.ContentCachingRequestWrapper;
 
 import javax.servlet.*;
@@ -11,13 +13,19 @@ import java.io.IOException;
  * inputStream을 읽으면 request body가 소진되기 때문에<br>
  * RequestWrapper를 사용하여 request body를 캐싱
  */
+@Component
+@Order(1)
 public class CachingRequestFilter implements Filter {
-
     @Override
-    public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws IOException, ServletException {
+    public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain)
+            throws IOException, ServletException {
+
         if (request instanceof HttpServletRequest) {
-            ContentCachingRequestWrapper wrappedRequest = new ContentCachingRequestWrapper((HttpServletRequest) request);
-            chain.doFilter(wrappedRequest, response);
+            System.out.println("[Filter] CachedBodyHttpServletRequest 적용됨");
+
+            HttpServletRequest httpServletRequest = (HttpServletRequest) request;
+            CachedBodyHttpServletRequest cachedRequest = new CachedBodyHttpServletRequest(httpServletRequest);
+            chain.doFilter(cachedRequest, response);
         } else {
             chain.doFilter(request, response);
         }

--- a/src/main/java/com/airbng/common/filter/RateLimitFilter.java
+++ b/src/main/java/com/airbng/common/filter/RateLimitFilter.java
@@ -1,0 +1,23 @@
+package com.airbng.common.filter;
+
+import org.springframework.core.annotation.Order;
+import org.springframework.stereotype.Component;
+
+import javax.servlet.*;
+import javax.servlet.http.HttpServletRequest;
+import java.io.IOException;
+
+@Component
+@Order(1)
+public class RateLimitFilter implements Filter {
+    @Override
+    public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws IOException, ServletException {
+        if (request instanceof HttpServletRequest) {
+            HttpServletRequest httpServletRequest = (HttpServletRequest) request;
+            CachedBodyHttpServletRequest cachedRequest = new CachedBodyHttpServletRequest(httpServletRequest);
+            chain.doFilter(cachedRequest, response);
+        } else {
+            chain.doFilter(request, response);
+        }
+    }
+}

--- a/src/main/java/com/airbng/common/response/status/BaseResponseStatus.java
+++ b/src/main/java/com/airbng/common/response/status/BaseResponseStatus.java
@@ -79,9 +79,10 @@ public enum BaseResponseStatus implements ResponseStatus{
     /**
      * 9000: sesssion
      */
-    SESSION_NOT_FOUND(7000, HttpStatus.UNAUTHORIZED.value(), "세션이 존재하지 않습니다. 다시 로그인해주세요."),
-    SESSION_INVALID_TYPE(7001, HttpStatus.UNAUTHORIZED.value(), "세션 정보가 올바르지 않습니다."),
-    SESSION_EXPIRED(7002, HttpStatus.UNAUTHORIZED.value(), "세션이 만료되었습니다."),
+    SESSION_MISMATCH(9001, HttpStatus.UNAUTHORIZED.value(), "세션의 사용자와 요청된 사용자 ID가 일치하지 않습니다."),
+    SESSION_NOT_FOUND(9002, HttpStatus.UNAUTHORIZED.value(), "세션이 존재하지 않습니다. 다시 로그인해주세요."),
+    SESSION_INVALID_TYPE(9003, HttpStatus.UNAUTHORIZED.value(), "세션 정보가 올바르지 않습니다."),
+    SESSION_EXPIRED(9004, HttpStatus.UNAUTHORIZED.value(), "세션이 만료되었습니다."),
 
     ;
 

--- a/src/main/java/com/airbng/common/response/status/BaseResponseStatus.java
+++ b/src/main/java/com/airbng/common/response/status/BaseResponseStatus.java
@@ -29,9 +29,9 @@ public enum BaseResponseStatus implements ResponseStatus{
     /**
      * 3000 락커 관련 코드
      */
-    NOT_FOUND_LOCKER(3000,HttpStatus.BAD_REQUEST.value(), "락커를 찾을 수 없습니다."),
-    NOT_FOUND_LOCKERDETAILS(3001,HttpStatus.BAD_REQUEST.value(), "락커를 찾을 수 없습니다."),
-    MEMBER_ALREADY_HAS_LOCKER(3002, HttpStatus.BAD_REQUEST.value(), "한 멤버당 하나의 보관소만 등록할 수 있습니다."),
+    NOT_FOUND_LOCKER(3001,HttpStatus.BAD_REQUEST.value(), "락커를 찾을 수 없습니다."),
+    NOT_FOUND_LOCKERDETAILS(3002,HttpStatus.BAD_REQUEST.value(), "락커를 찾을 수 없습니다."),
+    MEMBER_ALREADY_HAS_LOCKER(3003, HttpStatus.BAD_REQUEST.value(), "한 멤버당 하나의 보관소만 등록할 수 있습니다."),
     LOCKER_KEEPER_MISMATCH(3004, HttpStatus.BAD_REQUEST.value(), "선택한 보관소의 보관자 정보가 일치하지 않습니다."),
     /**
      * 4000 예약 관련 코드
@@ -46,10 +46,10 @@ public enum BaseResponseStatus implements ResponseStatus{
     /**
      * 5000 짐 타입 관련 코드
      */
-    INVALID_JIMTYPE(5000, HttpStatus.UNPROCESSABLE_ENTITY.value(), "존재하지 않는 짐 타입이 포함되어 있습니다."),
-    INVALID_JIMTYPE_COUNT(5001, HttpStatus.BAD_REQUEST.value(), "요청한 짐 타입 개수와 실제 등록된 개수가 일치하지 않습니다."),
-    LOCKER_DOES_NOT_SUPPORT_JIMTYPE(5002, HttpStatus.BAD_REQUEST.value(), "해당 보관소가 관리하지 않는 짐 타입입니다."),
-    DUPLICATE_JIMTYPE(5003, HttpStatus.BAD_REQUEST.value(), "중복된 짐 타입이 존재합니다."),
+    INVALID_JIMTYPE(5001, HttpStatus.UNPROCESSABLE_ENTITY.value(), "존재하지 않는 짐 타입이 포함되어 있습니다."),
+    INVALID_JIMTYPE_COUNT(5002, HttpStatus.BAD_REQUEST.value(), "요청한 짐 타입 개수와 실제 등록된 개수가 일치하지 않습니다."),
+    LOCKER_DOES_NOT_SUPPORT_JIMTYPE(5003, HttpStatus.BAD_REQUEST.value(), "해당 보관소가 관리하지 않는 짐 타입입니다."),
+    DUPLICATE_JIMTYPE(5004, HttpStatus.BAD_REQUEST.value(), "중복된 짐 타입이 존재합니다."),
     /**
      * 6000: image
      */
@@ -58,8 +58,11 @@ public enum BaseResponseStatus implements ResponseStatus{
     INVALID_EXTENSIONS(6003, HttpStatus.UNSUPPORTED_MEDIA_TYPE.value(),"허용되지 않는 파일 확장자입니다."),
     EXCEED_IMAGE_COUNT(6004, HttpStatus.PAYLOAD_TOO_LARGE.value(), "이미지 개수가 초과되었습니다. 최대 5개까지 업로드 가능합니다."),
 
-
-
+    /**
+     * 7000: 찜 관련 코드
+     */
+    DUPLICATE_ZZIM(7001, HttpStatus.BAD_REQUEST.value(), "이미 찜한 락커입니다."),
+    SELF_LOCKER_ZZIM(7002, HttpStatus.BAD_REQUEST.value(), "자신의 보관소는 찜할 수 없습니다."),
     ;
 
     private final int code;

--- a/src/main/java/com/airbng/common/response/status/BaseResponseStatus.java
+++ b/src/main/java/com/airbng/common/response/status/BaseResponseStatus.java
@@ -74,7 +74,9 @@ public enum BaseResponseStatus implements ResponseStatus{
     /**
      * 8000: DDOS / 보안 관련 코드
      */
-    DDOS_PREVENTION(8000, HttpStatus.TOO_MANY_REQUESTS.value(), "요청이 너무 빠릅니다. 잠시 후 다시 시도해주세요."),
+    DDOS_PREVENTION(8001, HttpStatus.TOO_MANY_REQUESTS.value(), "요청이 너무 빠릅니다. 잠시 후 다시 시도해주세요."),
+    REQUEST_RATE_LIMIT_EXCEEDED(8002, HttpStatus.TOO_MANY_REQUESTS.value(), "너무 많은 요청 발생. 잠시 후 다시 시도해주세요."),
+    LOGIN_RATE_LIMIT_EXCEEDED(8003, HttpStatus.TOO_MANY_REQUESTS.value(), "로그인 시도 횟수를 초과했습니다. 잠시 후 다시 시도해주세요."),
 
     /**
      * 9000: sesssion

--- a/src/main/java/com/airbng/common/response/status/BaseResponseStatus.java
+++ b/src/main/java/com/airbng/common/response/status/BaseResponseStatus.java
@@ -63,6 +63,12 @@ public enum BaseResponseStatus implements ResponseStatus{
      */
     DUPLICATE_ZZIM(7001, HttpStatus.BAD_REQUEST.value(), "이미 찜한 락커입니다."),
     SELF_LOCKER_ZZIM(7002, HttpStatus.BAD_REQUEST.value(), "자신의 보관소는 찜할 수 없습니다."),
+
+    /**
+     * 8000: DDOS / 보안 관련 코드
+     */
+    DDOS_PREVENTION(8000, HttpStatus.TOO_MANY_REQUESTS.value(), "요청이 너무 빠릅니다. 잠시 후 다시 시도해주세요."),
+
     ;
 
     private final int code;

--- a/src/main/java/com/airbng/common/response/status/BaseResponseStatus.java
+++ b/src/main/java/com/airbng/common/response/status/BaseResponseStatus.java
@@ -61,8 +61,11 @@ public enum BaseResponseStatus implements ResponseStatus{
     /**
      * 7000: 찜 관련 코드
      */
-    DUPLICATE_ZZIM(7001, HttpStatus.BAD_REQUEST.value(), "이미 찜한 락커입니다."),
-    SELF_LOCKER_ZZIM(7002, HttpStatus.BAD_REQUEST.value(), "자신의 보관소는 찜할 수 없습니다."),
+    // 찜 등록 성공
+    SUCCESS_INSERT_ZZIM(7000, HttpStatus.OK.value(), "찜 등록에 성공하였습니다."),
+    SUCCESS_DELETE_ZZIM(7001, HttpStatus.OK.value(), "찜 취소에 성공하였습니다."),
+    DUPLICATE_ZZIM(7002, HttpStatus.BAD_REQUEST.value(), "이미 찜한 락커입니다."),
+    SELF_LOCKER_ZZIM(7003, HttpStatus.BAD_REQUEST.value(), "자신의 보관소는 찜할 수 없습니다."),
 
     /**
      * 8000: DDOS / 보안 관련 코드

--- a/src/main/java/com/airbng/config/RedisConfig.java
+++ b/src/main/java/com/airbng/config/RedisConfig.java
@@ -1,0 +1,56 @@
+package com.airbng.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.PropertySource;
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+import org.springframework.session.data.redis.config.annotation.web.http.EnableRedisHttpSession;
+
+@Configuration
+@PropertySource("classpath:application.properties")
+@EnableRedisHttpSession
+public class RedisConfig {
+
+    @Value("${redis.host}")
+    private String redisHost;
+
+    @Value("${redis.port}")
+    private int redisPort;
+
+    @Value("${redis.password:}")
+    private String redisPassword;
+
+    @Bean
+    public LettuceConnectionFactory redisConnectionFactory() {
+        RedisStandaloneConfiguration config = new RedisStandaloneConfiguration();
+        config.setHostName(redisHost);
+        config.setPort(redisPort);
+        if (redisPassword != null && !redisPassword.trim().isEmpty()) {
+            config.setPassword(redisPassword);
+        }
+        return new LettuceConnectionFactory(config);
+    }
+
+    @Bean
+    public StringRedisTemplate stringRedisTemplate() {
+        StringRedisTemplate template = new StringRedisTemplate();
+        template.setConnectionFactory(redisConnectionFactory());
+        template.setKeySerializer(new StringRedisSerializer());
+        template.setValueSerializer(new StringRedisSerializer());
+        return template;
+    }
+
+    @Bean
+    public RedisTemplate<String, Object> redisTemplate() {
+        RedisTemplate<String, Object> template = new RedisTemplate<>();
+        template.setConnectionFactory(redisConnectionFactory());
+        template.setKeySerializer(new StringRedisSerializer());
+        template.setValueSerializer(new StringRedisSerializer());
+        return template;
+    }
+}

--- a/src/main/java/com/airbng/config/SwaggerConfig.java
+++ b/src/main/java/com/airbng/config/SwaggerConfig.java
@@ -17,7 +17,7 @@ public class SwaggerConfig {
     @Bean
     public Docket api() {
         return new Docket(DocumentationType.SWAGGER_2)
-        		.select()
+                .select()
                 .apis(RequestHandlerSelectors.basePackage("com.airbng"))
                 .paths(PathSelectors.any())
                 .build()

--- a/src/main/java/com/airbng/config/WebAppInitializer.java
+++ b/src/main/java/com/airbng/config/WebAppInitializer.java
@@ -1,6 +1,7 @@
 package com.airbng.config;
 
 import com.airbng.common.filter.CachingRequestFilter;
+import com.airbng.common.filter.RateLimitFilter;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.WebApplicationInitializer;
 
@@ -12,7 +13,12 @@ import javax.servlet.ServletException;
 public class WebAppInitializer implements WebApplicationInitializer {
     @Override
     public void onStartup(ServletContext servletContext) {
+
+        FilterRegistration.Dynamic rateLimitFilter = servletContext.addFilter("rateLimitFilter", new RateLimitFilter());
+        rateLimitFilter.addMappingForUrlPatterns(null, false, "/*");
+
         FilterRegistration.Dynamic cachingFilter = servletContext.addFilter("cachingRequestFilter", new CachingRequestFilter());
         cachingFilter.addMappingForUrlPatterns(null, false, "/*");
+
     }
 }

--- a/src/main/java/com/airbng/config/WebConfig.java
+++ b/src/main/java/com/airbng/config/WebConfig.java
@@ -37,11 +37,9 @@ public class WebConfig implements WebMvcConfigurer {
 
     @Override
     public void addInterceptors(InterceptorRegistry registry) {
-        // 요청 속도 제한 인터셉터 등록
-        registry.addInterceptor(rateLimitInterceptor)
-//                .addPathPatterns("/**") // 모든 경로에 적용
-                .addPathPatterns("/zzim/**", "/lockers/**")
-                .excludePathPatterns("/swagger-ui/**", "/v3/api-docs/**"); // Swagger 관련 경로 제외
+        registry.addInterceptor(rateLimitInterceptor) // 메서드로 직접 호출
+                .addPathPatterns("/lockers/**/members/**/zzim")
+                .excludePathPatterns("/swagger-ui/**", "/v3/api-docs/**");
     }
 
     //이미지 파일 처리
@@ -52,4 +50,5 @@ public class WebConfig implements WebMvcConfigurer {
         resolver.setMaxUploadSize(10 * 1024 * 1024); // 10MB
         return resolver;
     }
+
 }

--- a/src/main/java/com/airbng/config/WebConfig.java
+++ b/src/main/java/com/airbng/config/WebConfig.java
@@ -1,5 +1,7 @@
 package com.airbng.config;
 
+import com.airbng.interceptor.RequestRateLimitInterceptor;
+import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
@@ -11,7 +13,10 @@ import org.springframework.web.servlet.config.annotation.*;
 @EnableWebMvc
 @ComponentScan(basePackages = "com.airbng")
 @EnableTransactionManagement
+@RequiredArgsConstructor
 public class WebConfig implements WebMvcConfigurer {
+
+    private final RequestRateLimitInterceptor rateLimitInterceptor;
 
     @Override
     public void configureViewResolvers(ViewResolverRegistry registry) {
@@ -28,6 +33,15 @@ public class WebConfig implements WebMvcConfigurer {
         registry.addResourceHandler("swagger-ui.html")
                 .addResourceLocations("classpath:/META-INF/resources/");
 
+    }
+
+    @Override
+    public void addInterceptors(InterceptorRegistry registry) {
+        // 요청 속도 제한 인터셉터 등록
+        registry.addInterceptor(rateLimitInterceptor)
+//                .addPathPatterns("/**") // 모든 경로에 적용
+                .addPathPatterns("/zzim/**", "/lockers/**")
+                .excludePathPatterns("/swagger-ui/**", "/v3/api-docs/**"); // Swagger 관련 경로 제외
     }
 
     //이미지 파일 처리

--- a/src/main/java/com/airbng/controller/MemberController.java
+++ b/src/main/java/com/airbng/controller/MemberController.java
@@ -1,8 +1,6 @@
 package com.airbng.controller;
 
-
 import com.airbng.common.response.BaseResponse;
-import com.airbng.domain.Member;
 import com.airbng.dto.MemberLoginRequest;
 import com.airbng.dto.MemberLoginResponse;
 import com.airbng.dto.MemberSignupRequest;
@@ -14,9 +12,9 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
+import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpSession;
 
-import static com.airbng.common.response.status.BaseResponseStatus.SUCCESS;
 import static com.airbng.common.response.status.BaseResponseStatus.SUCCESS_LOGIN;
 
 @RestController
@@ -44,16 +42,18 @@ public class MemberController {
 
     @PostMapping("/login")
     public BaseResponse<MemberLoginResponse> login(@RequestBody MemberLoginRequest request,
-                                                   HttpSession session) {
+                                                   HttpSession session,
+                                                   HttpServletRequest httpRequest) {
+        log.info("Controller 도달");
+
+        // Interceptor에서 참조 가능하게 세팅
+        httpRequest.setAttribute("loginEmail", request.getEmail());
         log.info("로그인 요청: email={}, password={}", request.getEmail(), request.getPassword());
 
         MemberLoginResponse response = memberService.login(request.getEmail(), request.getPassword());
-
         log.info("로그인 결과: {}", response);
 
-        // 세션에 memberId 저장
         session.setAttribute("memberId", response.getMemberId());
-
         return new BaseResponse<>(SUCCESS_LOGIN, response);
     }
 

--- a/src/main/java/com/airbng/controller/ZzimController.java
+++ b/src/main/java/com/airbng/controller/ZzimController.java
@@ -1,11 +1,17 @@
 package com.airbng.controller;
 
+import com.airbng.common.exception.MemberException;
 import com.airbng.common.response.BaseResponse;
+import com.airbng.common.response.status.BaseResponseStatus;
 import com.airbng.service.ZzimService;
+import com.airbng.util.SessionUtils;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+
+import javax.servlet.http.HttpSession;
+import java.util.Objects;
 
 @Slf4j
 @RestController
@@ -18,11 +24,18 @@ public class ZzimController {
      * 찜 등록 또는 취소 (토글 방식)
      */
     @PostMapping("/lockers/{lockerId}/members/{memberId}/zzim")
-    public ResponseEntity<BaseResponse<String>> toggleZzim(@PathVariable Long memberId,
-                                                           @PathVariable Long lockerId) {
-        boolean added = zzimService.toggleZzim(memberId, lockerId);
-        String message = added ? "찜 등록 완료" : "찜 취소 완료";
-        return ResponseEntity.ok(new BaseResponse<>(message));
+    public ResponseEntity<BaseResponseStatus> toggleZzim(
+            @PathVariable Long lockerId,
+            @PathVariable Long memberId,
+            HttpSession session) {
+
+        Long sessionMemberId = SessionUtils.getLoginMemberId(session);
+        if (!Objects.equals(sessionMemberId, memberId)) {
+            throw new MemberException(BaseResponseStatus.NOT_FOUND_MEMBER);
+        }
+
+        BaseResponseStatus status = zzimService.toggleZzim(memberId, lockerId);
+        return ResponseEntity.status(status.getHttpStatus()).body(status);
     }
 
     /**

--- a/src/main/java/com/airbng/controller/ZzimController.java
+++ b/src/main/java/com/airbng/controller/ZzimController.java
@@ -5,6 +5,7 @@ import com.airbng.common.response.BaseResponse;
 import com.airbng.common.response.status.BaseResponseStatus;
 import com.airbng.service.ZzimService;
 import com.airbng.util.SessionUtils;
+import com.amazonaws.Response;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
@@ -12,6 +13,8 @@ import org.springframework.web.bind.annotation.*;
 
 import javax.servlet.http.HttpSession;
 import java.util.Objects;
+
+import static com.airbng.common.response.status.BaseResponseStatus.NOT_FOUND_MEMBER;
 
 @Slf4j
 @RestController
@@ -24,18 +27,16 @@ public class ZzimController {
      * 찜 등록 또는 취소 (토글 방식)
      */
     @PostMapping("/lockers/{lockerId}/members/{memberId}/zzim")
-    public ResponseEntity<BaseResponseStatus> toggleZzim(
+    public ResponseEntity<BaseResponse<BaseResponseStatus>> toggleZzim(
             @PathVariable Long lockerId,
             @PathVariable Long memberId,
             HttpSession session) {
 
         Long sessionMemberId = SessionUtils.getLoginMemberId(session);
-        if (!Objects.equals(sessionMemberId, memberId)) {
-            throw new MemberException(BaseResponseStatus.NOT_FOUND_MEMBER);
-        }
 
-        BaseResponseStatus status = zzimService.toggleZzim(memberId, lockerId);
-        return ResponseEntity.status(status.getHttpStatus()).body(status);
+        BaseResponseStatus status = zzimService.toggleZzim(sessionMemberId, memberId, lockerId);
+        return ResponseEntity.status(status.getHttpStatus())
+                .body(new BaseResponse<>(status));
     }
 
     /**

--- a/src/main/java/com/airbng/controller/ZzimController.java
+++ b/src/main/java/com/airbng/controller/ZzimController.java
@@ -1,0 +1,37 @@
+package com.airbng.controller;
+
+import com.airbng.common.response.BaseResponse;
+import com.airbng.service.ZzimService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+public class ZzimController {
+
+    private final ZzimService zzimService;
+
+    /**
+     * 찜 등록 또는 취소 (토글 방식)
+     */
+    @PostMapping("/lockers/{lockerId}/members/{memberId}/zzim")
+    public ResponseEntity<BaseResponse<String>> toggleZzim(@PathVariable Long memberId,
+                                                           @PathVariable Long lockerId) {
+        boolean added = zzimService.toggleZzim(memberId, lockerId);
+        String message = added ? "찜 등록 완료" : "찜 취소 완료";
+        return ResponseEntity.ok(new BaseResponse<>(message));
+    }
+
+    /**
+     * 찜 여부 확인
+     */
+    @GetMapping("/lockers/{lockerId}/members/{memberId}/zzim/exists")
+    public ResponseEntity<BaseResponse<Boolean>> existsZzim(@PathVariable Long memberId,
+                                                            @PathVariable Long lockerId) {
+        boolean exists = zzimService.isExistZzim(memberId, lockerId);
+        return ResponseEntity.ok(new BaseResponse<>(exists));
+    }
+}

--- a/src/main/java/com/airbng/domain/Zzim.java
+++ b/src/main/java/com/airbng/domain/Zzim.java
@@ -1,0 +1,19 @@
+package com.airbng.domain;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class Zzim {
+    private Long lockerId;
+    private Long memberId;
+
+    // 조회용
+    private Locker locker;
+    private Member member;
+}

--- a/src/main/java/com/airbng/interceptor/LoginRateLimitInterceptor.java
+++ b/src/main/java/com/airbng/interceptor/LoginRateLimitInterceptor.java
@@ -1,0 +1,64 @@
+package com.airbng.interceptor;
+
+import com.airbng.common.response.BaseResponse;
+import com.airbng.util.ResponseUtils;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.BufferedReader;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+
+import static com.airbng.common.response.status.BaseResponseStatus.LOGIN_RATE_LIMIT_EXCEEDED;
+
+@Component
+@RequiredArgsConstructor
+public class LoginRateLimitInterceptor implements HandlerInterceptor {
+
+    private final StringRedisTemplate redisTemplate;
+
+    @Override
+    public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) throws Exception {
+        if (!request.getRequestURI().contains("/members/login")) return true;
+
+        // JSON body에서 직접 email 추출
+        String body = new BufferedReader(request.getReader())
+                .lines().collect(Collectors.joining());
+        ObjectMapper mapper = new ObjectMapper();
+        JsonNode root = mapper.readTree(body);
+        String email = root.has("email") ? root.get("email").asText() : null;
+
+        System.out.println("[Interceptor] 추출된 email = " + email);
+
+        if (email == null || email.isEmpty()) {
+            System.err.println("[Interceptor] loginEmail 누락 – 요청 거부");
+            response.setStatus(HttpStatus.BAD_REQUEST.value());
+            response.getWriter().write("이메일 누락");
+            return false;
+        }
+
+        String key = "login:limit:" + email;
+        Long count = redisTemplate.opsForValue().increment(key);
+        System.out.println("Redis 로그인 시도 횟수: " + count + " (key: " + key + ")");
+
+        if (count != null && count == 1) {
+            redisTemplate.expire(key, 60, TimeUnit.SECONDS);
+        }
+
+        if (count != null && count > 5) {
+            ResponseUtils.writeErrorResponse(response, LOGIN_RATE_LIMIT_EXCEEDED);
+            return false;
+        }
+
+        return true;
+    }
+
+
+}

--- a/src/main/java/com/airbng/interceptor/RedisRateLimitInterceptor.java
+++ b/src/main/java/com/airbng/interceptor/RedisRateLimitInterceptor.java
@@ -1,0 +1,40 @@
+package com.airbng.interceptor;
+
+import com.airbng.util.ResponseUtils;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.PrintWriter;
+import java.util.concurrent.TimeUnit;
+
+import static com.airbng.common.response.status.BaseResponseStatus.REQUEST_RATE_LIMIT_EXCEEDED;
+
+@Component
+@RequiredArgsConstructor
+public class RedisRateLimitInterceptor implements HandlerInterceptor {
+
+    private final StringRedisTemplate redisTemplate;
+
+    private static final int LIMIT_INTERVAL_SECONDS = 1;
+
+    @Override
+    public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) throws Exception {
+        String ip = request.getRemoteAddr();
+        String key = "ratelimit:" + ip;
+
+        Long count = redisTemplate.opsForValue().increment(key);
+
+        if (count != null && count == 1L) {
+            redisTemplate.expire(key, LIMIT_INTERVAL_SECONDS, TimeUnit.SECONDS);
+            return true;
+        } else {
+            ResponseUtils.writeErrorResponse(response, REQUEST_RATE_LIMIT_EXCEEDED);
+            return false;
+        }
+    }
+}

--- a/src/main/java/com/airbng/interceptor/RequestRateLimitInterceptor.java
+++ b/src/main/java/com/airbng/interceptor/RequestRateLimitInterceptor.java
@@ -11,6 +11,8 @@ import java.io.IOException;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
+import static com.airbng.common.response.status.BaseResponseStatus.DDOS_PREVENTION;
+
 @Slf4j
 @Component
 public class RequestRateLimitInterceptor implements HandlerInterceptor {
@@ -26,8 +28,8 @@ public class RequestRateLimitInterceptor implements HandlerInterceptor {
 
         if (now - lastTime < LIMIT_MILLIS) {
             log.warn("DDOS 차단 - key={}, path={}", key, request.getRequestURI());
-            response.setStatus(429); // HTTP 429 Too Many Requests
-            response.getWriter().write("요청이 너무 빠릅니다. 잠시 후 다시 시도해주세요.");
+            response.setStatus(DDOS_PREVENTION.getHttpStatus());
+            response.getWriter().write(DDOS_PREVENTION.getMessage());
             return false;
         }
 
@@ -36,8 +38,7 @@ public class RequestRateLimitInterceptor implements HandlerInterceptor {
     }
 
     private String getKey(HttpServletRequest request) {
-        Long memberId = SessionUtils.getMemberId(request);
-        return (memberId != null ? "user:" + memberId : "ip:" + request.getRemoteAddr()) +
-                ":" + request.getRequestURI();
+        Object memberId = request.getSession().getAttribute("memberId");
+        return (memberId != null ? "user:" + memberId : "ip:" + request.getRemoteAddr()) + ":" + request.getRequestURI();
     }
 }

--- a/src/main/java/com/airbng/interceptor/RequestRateLimitInterceptor.java
+++ b/src/main/java/com/airbng/interceptor/RequestRateLimitInterceptor.java
@@ -1,0 +1,43 @@
+package com.airbng.interceptor;
+
+import com.airbng.util.SessionUtils;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+@Slf4j
+@Component
+public class RequestRateLimitInterceptor implements HandlerInterceptor {
+
+    private static final long LIMIT_MILLIS = 1000; // 1초 제한
+    private final Map<String, Long> lastRequestMap = new ConcurrentHashMap<>();
+
+    @Override
+    public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) throws IOException {
+        String key = getKey(request);
+        long now = System.currentTimeMillis();
+        long lastTime = lastRequestMap.getOrDefault(key, 0L);
+
+        if (now - lastTime < LIMIT_MILLIS) {
+            log.warn("DDOS 차단 - key={}, path={}", key, request.getRequestURI());
+            response.setStatus(429); // HTTP 429 Too Many Requests
+            response.getWriter().write("요청이 너무 빠릅니다. 잠시 후 다시 시도해주세요.");
+            return false;
+        }
+
+        lastRequestMap.put(key, now);
+        return true;
+    }
+
+    private String getKey(HttpServletRequest request) {
+        Long memberId = SessionUtils.getMemberId(request);
+        return (memberId != null ? "user:" + memberId : "ip:" + request.getRemoteAddr()) +
+                ":" + request.getRequestURI();
+    }
+}

--- a/src/main/java/com/airbng/interceptor/RequestRateLimitInterceptor.java
+++ b/src/main/java/com/airbng/interceptor/RequestRateLimitInterceptor.java
@@ -1,13 +1,14 @@
 package com.airbng.interceptor;
 
-import com.airbng.util.SessionUtils;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 import org.springframework.web.servlet.HandlerInterceptor;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+import javax.servlet.http.HttpSession;
 import java.io.IOException;
+import java.time.Clock;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
@@ -17,28 +18,61 @@ import static com.airbng.common.response.status.BaseResponseStatus.DDOS_PREVENTI
 @Component
 public class RequestRateLimitInterceptor implements HandlerInterceptor {
 
-    private static final long LIMIT_MILLIS = 1000; // 1초 제한
-    private final Map<String, Long> lastRequestMap = new ConcurrentHashMap<>();
+    private static final int MAX_REPEAT_COUNT = 100;
+    private static final long BLOCK_DURATION = 30_000L;
+
+    private final Map<String, Integer> requestCountMap = new ConcurrentHashMap<>();
+    private final Map<String, Long> blockUntilMap = new ConcurrentHashMap<>();
+    private final Clock clock;
+
+    // 기본 생성자
+    public RequestRateLimitInterceptor() {
+        this(Clock.systemDefaultZone());
+    }
+
+    // 테스트용
+    public RequestRateLimitInterceptor(Clock clock) {
+        this.clock = clock;
+    }
 
     @Override
     public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) throws IOException {
         String key = getKey(request);
-        long now = System.currentTimeMillis();
-        long lastTime = lastRequestMap.getOrDefault(key, 0L);
+        long now = clock.millis();
 
-        if (now - lastTime < LIMIT_MILLIS) {
-            log.warn("DDOS 차단 - key={}, path={}", key, request.getRequestURI());
+        if (blockUntilMap.containsKey(key)) {
+            long blockUntil = blockUntilMap.get(key);
+            if (now < blockUntil) {
+                response.setStatus(DDOS_PREVENTION.getHttpStatus());
+                response.getWriter().write("요청이 너무 많습니다. 30초 동안 차단됩니다.");
+                return false;
+            }
+            blockUntilMap.remove(key);
+            requestCountMap.remove(key);
+        }
+
+        int count = requestCountMap.getOrDefault(key, 0) + 1;
+        requestCountMap.put(key, count);
+
+        if (count > MAX_REPEAT_COUNT) {
+            blockUntilMap.put(key, now + BLOCK_DURATION);
+            requestCountMap.remove(key);
             response.setStatus(DDOS_PREVENTION.getHttpStatus());
-            response.getWriter().write(DDOS_PREVENTION.getMessage());
+            response.getWriter().write("요청이 너무 많습니다. 30초 동안 차단됩니다.");
             return false;
         }
 
-        lastRequestMap.put(key, now);
         return true;
     }
 
     private String getKey(HttpServletRequest request) {
-        Object memberId = request.getSession().getAttribute("memberId");
-        return (memberId != null ? "user:" + memberId : "ip:" + request.getRemoteAddr()) + ":" + request.getRequestURI();
+        HttpSession session = request.getSession(false);
+        if (session != null) {
+            Object memberId = session.getAttribute("memberId");
+            if (memberId != null) {
+                return "user:" + memberId + ":" + request.getRequestURI();
+            }
+        }
+        return "ip:" + request.getRemoteAddr() + ":" + request.getRequestURI();
     }
 }

--- a/src/main/java/com/airbng/mappers/ZzimMapper.java
+++ b/src/main/java/com/airbng/mappers/ZzimMapper.java
@@ -1,0 +1,15 @@
+package com.airbng.mappers;
+
+import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
+
+@Mapper
+public interface ZzimMapper {
+
+    int isExistZzim(@Param("memberId") Long memberId, @Param("lockerId") Long lockerId);
+
+    void insertZzim(@Param("memberId") Long memberId, @Param("lockerId") Long lockerId);
+
+    void deleteZzim(@Param("memberId") Long memberId, @Param("lockerId") Long lockerId);
+
+}

--- a/src/main/java/com/airbng/mappers/ZzimMapper.java
+++ b/src/main/java/com/airbng/mappers/ZzimMapper.java
@@ -12,4 +12,8 @@ public interface ZzimMapper {
 
     void deleteZzim(@Param("memberId") Long memberId, @Param("lockerId") Long lockerId);
 
+    void increaseZzimCount(@Param("lockerId") Long lockerId);
+
+    void decreaseZzimCount(@Param("lockerId") Long lockerId);
+
 }

--- a/src/main/java/com/airbng/service/ZzimService.java
+++ b/src/main/java/com/airbng/service/ZzimService.java
@@ -6,6 +6,6 @@ public interface ZzimService {
 
     boolean isExistZzim(Long memberId, Long lockerId);
 
-    BaseResponseStatus toggleZzim(Long memberId, Long lockerId);
+    BaseResponseStatus toggleZzim(Long sessionMemberId, Long memberId, Long lockerId);
 
 }

--- a/src/main/java/com/airbng/service/ZzimService.java
+++ b/src/main/java/com/airbng/service/ZzimService.java
@@ -1,0 +1,13 @@
+package com.airbng.service;
+
+import com.airbng.domain.Zzim;
+
+import java.util.List;
+
+public interface ZzimService {
+
+    boolean isExistZzim(Long memberId, Long lockerId);
+
+    boolean toggleZzim(Long memberId, Long lockerId);
+
+}

--- a/src/main/java/com/airbng/service/ZzimService.java
+++ b/src/main/java/com/airbng/service/ZzimService.java
@@ -1,13 +1,11 @@
 package com.airbng.service;
 
-import com.airbng.domain.Zzim;
-
-import java.util.List;
+import com.airbng.common.response.status.BaseResponseStatus;
 
 public interface ZzimService {
 
     boolean isExistZzim(Long memberId, Long lockerId);
 
-    boolean toggleZzim(Long memberId, Long lockerId);
+    BaseResponseStatus toggleZzim(Long memberId, Long lockerId);
 
 }

--- a/src/main/java/com/airbng/service/ZzimServiceImpl.java
+++ b/src/main/java/com/airbng/service/ZzimServiceImpl.java
@@ -2,6 +2,7 @@ package com.airbng.service;
 
 import com.airbng.common.exception.LockerException;
 import com.airbng.common.exception.MemberException;
+import com.airbng.common.exception.SessionException;
 import com.airbng.common.exception.ZzimException;
 import com.airbng.common.response.status.BaseResponseStatus;
 import com.airbng.mappers.LockerMapper;
@@ -11,6 +12,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.dao.DuplicateKeyException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Objects;
 
 import static com.airbng.common.response.status.BaseResponseStatus.*;
 
@@ -24,7 +27,12 @@ public class ZzimServiceImpl implements ZzimService {
 
     @Override
     @Transactional
-    public BaseResponseStatus toggleZzim(Long memberId, Long lockerId) {
+    public BaseResponseStatus toggleZzim(Long sessionMemberId, Long memberId, Long lockerId) {
+        // 세션의 사용자와 요청된 사용자 ID가 일치하는지 확인
+        if (!Objects.equals(sessionMemberId, memberId)) {
+            throw new SessionException(SESSION_MISMATCH);
+        }
+
         // 멤버 존재 여부 확인
         if (!memberMapper.isExistMember(memberId)) {
             throw new MemberException(NOT_FOUND_MEMBER);

--- a/src/main/java/com/airbng/service/ZzimServiceImpl.java
+++ b/src/main/java/com/airbng/service/ZzimServiceImpl.java
@@ -1,0 +1,59 @@
+package com.airbng.service;
+
+import com.airbng.common.exception.LockerException;
+import com.airbng.common.exception.MemberException;
+import com.airbng.common.exception.ZzimException;
+import com.airbng.common.response.status.BaseResponseStatus;
+import com.airbng.mappers.LockerMapper;
+import com.airbng.mappers.MemberMapper;
+import com.airbng.mappers.ZzimMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.dao.DuplicateKeyException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import static com.airbng.common.response.status.BaseResponseStatus.*;
+
+@Service
+@RequiredArgsConstructor
+public class ZzimServiceImpl implements ZzimService {
+
+    private final ZzimMapper zzimMapper;
+    private final MemberMapper memberMapper;
+    private final LockerMapper lockerMapper;
+
+    @Override
+    @Transactional
+    public boolean toggleZzim(Long memberId, Long lockerId) {
+        // 멤버 존재 여부 확인
+        if (!memberMapper.isExistMember(memberId)) {
+            throw new MemberException(NOT_FOUND_MEMBER);
+        }
+        // 락커 존재 여부 확인
+        if (!lockerMapper.isExistLocker(lockerId)) {
+            throw new LockerException(NOT_FOUND_LOCKER);
+        }
+        // 자기 락커 찜 금지
+        if (lockerMapper.isLockerKeeper(lockerId, memberId)) {
+            throw new ZzimException(SELF_LOCKER_ZZIM);
+        }
+        // 찜 존재 여부 확인 후 등록/삭제
+        if (zzimMapper.isExistZzim(memberId, lockerId) == 1) {
+            zzimMapper.deleteZzim(memberId, lockerId);
+            return false; // 취소됨
+        }
+
+        // 찜 등록 (중복 insert 예외 방지)
+        try {
+            zzimMapper.insertZzim(memberId, lockerId);
+            return true; // 찜 등록됨
+        } catch (DuplicateKeyException e) {
+            throw new ZzimException(DUPLICATE_ZZIM);
+        }
+    }
+
+    @Override
+    public boolean isExistZzim(Long memberId, Long lockerId) {
+        return zzimMapper.isExistZzim(memberId, lockerId) == 1;
+    }
+}

--- a/src/main/java/com/airbng/service/ZzimServiceImpl.java
+++ b/src/main/java/com/airbng/service/ZzimServiceImpl.java
@@ -24,7 +24,7 @@ public class ZzimServiceImpl implements ZzimService {
 
     @Override
     @Transactional
-    public boolean toggleZzim(Long memberId, Long lockerId) {
+    public BaseResponseStatus toggleZzim(Long memberId, Long lockerId) {
         // 멤버 존재 여부 확인
         if (!memberMapper.isExistMember(memberId)) {
             throw new MemberException(NOT_FOUND_MEMBER);
@@ -40,13 +40,13 @@ public class ZzimServiceImpl implements ZzimService {
         // 찜 존재 여부 확인 후 등록/삭제
         if (zzimMapper.isExistZzim(memberId, lockerId) == 1) {
             zzimMapper.deleteZzim(memberId, lockerId);
-            return false; // 취소됨
+            return SUCCESS_DELETE_ZZIM; // 취소됨
         }
 
         // 찜 등록 (중복 insert 예외 방지)
         try {
             zzimMapper.insertZzim(memberId, lockerId);
-            return true; // 찜 등록됨
+            return SUCCESS_INSERT_ZZIM; // 찜 등록됨
         } catch (DuplicateKeyException e) {
             throw new ZzimException(DUPLICATE_ZZIM);
         }

--- a/src/main/java/com/airbng/service/ZzimServiceImpl.java
+++ b/src/main/java/com/airbng/service/ZzimServiceImpl.java
@@ -47,13 +47,15 @@ public class ZzimServiceImpl implements ZzimService {
         }
         // 찜 존재 여부 확인 후 등록/삭제
         if (zzimMapper.isExistZzim(memberId, lockerId) == 1) {
-            zzimMapper.deleteZzim(memberId, lockerId);
+            zzimMapper.deleteZzim(memberId, lockerId); // zzim_count 감소
+            zzimMapper.decreaseZzimCount(lockerId);
             return SUCCESS_DELETE_ZZIM; // 취소됨
         }
 
         // 찜 등록 (중복 insert 예외 방지)
         try {
             zzimMapper.insertZzim(memberId, lockerId);
+            zzimMapper.increaseZzimCount(lockerId); // zzim_count 증가
             return SUCCESS_INSERT_ZZIM; // 찜 등록됨
         } catch (DuplicateKeyException e) {
             throw new ZzimException(DUPLICATE_ZZIM);

--- a/src/main/java/com/airbng/util/ResponseUtils.java
+++ b/src/main/java/com/airbng/util/ResponseUtils.java
@@ -1,0 +1,40 @@
+package com.airbng.util;
+
+import com.airbng.common.response.BaseResponse;
+import com.airbng.common.response.status.BaseResponseStatus;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.io.PrintWriter;
+
+public class ResponseUtils {
+
+    private static final ObjectMapper objectMapper = new ObjectMapper();
+
+    public static void writeErrorResponse(HttpServletResponse response, BaseResponseStatus status) throws IOException {
+        response.setStatus(status.getHttpStatus());
+        response.setContentType("application/json");
+        response.setCharacterEncoding("UTF-8");
+
+        BaseResponse<Object> errorResponse = new BaseResponse<>(status);
+        String json = objectMapper.writeValueAsString(errorResponse);
+
+        PrintWriter writer = response.getWriter();
+        writer.write(json);
+        writer.flush();
+    }
+
+    public static void writeSuccessResponse(HttpServletResponse response, BaseResponseStatus status) throws IOException {
+        response.setStatus(status.getHttpStatus());
+        response.setContentType("application/json");
+        response.setCharacterEncoding("UTF-8");
+
+        BaseResponse<Object> successResponse = new BaseResponse<>(status);
+        String json = objectMapper.writeValueAsString(successResponse);
+
+        PrintWriter writer = response.getWriter();
+        writer.write(json);
+        writer.flush();
+    }
+}

--- a/src/main/java/com/airbng/util/SessionUtils.java
+++ b/src/main/java/com/airbng/util/SessionUtils.java
@@ -1,7 +1,12 @@
 package com.airbng.util;
 
+import com.airbng.common.exception.MemberException;
+import com.airbng.common.response.status.BaseResponseStatus;
+
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpSession;
+
+import static com.airbng.common.response.status.BaseResponseStatus.NOT_FOUND_MEMBER;
 
 public class SessionUtils {
 
@@ -21,5 +26,13 @@ public class SessionUtils {
      */
     public static boolean isLoggedIn(HttpServletRequest request) {
         return getMemberId(request) != null;
+    }
+
+    public static Long getLoginMemberId(HttpSession session) {
+        Object memberId = session.getAttribute("memberId");
+        if (memberId == null || !(memberId instanceof Long)) {
+            throw new MemberException(NOT_FOUND_MEMBER);
+        }
+        return (Long) memberId;
     }
 }

--- a/src/main/java/com/airbng/util/SessionUtils.java
+++ b/src/main/java/com/airbng/util/SessionUtils.java
@@ -1,6 +1,7 @@
 package com.airbng.util;
 
 import com.airbng.common.exception.MemberException;
+import com.airbng.common.exception.SessionException;
 import com.airbng.common.response.status.BaseResponseStatus;
 
 import javax.servlet.http.HttpServletRequest;
@@ -30,16 +31,16 @@ public class SessionUtils {
 
     public static Long getLoginMemberId(HttpSession session) {
         if (session == null) {
-            throw new MemberException(SESSION_NOT_FOUND);
+            throw new SessionException(SESSION_EXPIRED);
         }
 
         Object memberId = session.getAttribute("memberId");
         if (memberId == null) {
-            throw new MemberException(SESSION_NOT_FOUND);
+            throw new SessionException(SESSION_NOT_FOUND);
         }
 
         if (!(memberId instanceof Long)) {
-            throw new MemberException(SESSION_INVALID_TYPE);
+            throw new SessionException(SESSION_INVALID_TYPE);
         }
         return (Long) memberId;
     }

--- a/src/main/java/com/airbng/util/SessionUtils.java
+++ b/src/main/java/com/airbng/util/SessionUtils.java
@@ -1,0 +1,25 @@
+package com.airbng.util;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpSession;
+
+public class SessionUtils {
+
+    /**
+     * 세션에서 memberId를 꺼낸다. 없으면 null 반환
+     */
+    public static Long getMemberId(HttpServletRequest request) {
+        HttpSession session = request.getSession(false);
+        if (session == null) return null;
+
+        Object value = session.getAttribute("memberId");
+        return (value instanceof Long) ? (Long) value : null;
+    }
+
+    /**
+     * 로그인 여부 판단
+     */
+    public static boolean isLoggedIn(HttpServletRequest request) {
+        return getMemberId(request) != null;
+    }
+}

--- a/src/main/resources/mappers/ZzimMapper.xml
+++ b/src/main/resources/mappers/ZzimMapper.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE mapper
+        PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="com.airbng.mappers.ZzimMapper">
+
+    <select id="isExistZzim" resultType="int">
+        SELECT EXISTS (
+        SELECT 1 FROM Zzim
+        WHERE member_id = #{memberId}
+        AND locker_id = #{lockerId}
+        )
+    </select>
+
+    <insert id="insertZzim">
+        INSERT INTO Zzim (member_id, locker_id)
+        VALUES (#{memberId}, #{lockerId})
+    </insert>
+
+    <delete id="deleteZzim">
+        DELETE FROM Zzim
+        WHERE member_id = #{memberId}
+        AND locker_id = #{lockerId}
+    </delete>
+
+</mapper>

--- a/src/main/resources/mappers/ZzimMapper.xml
+++ b/src/main/resources/mappers/ZzimMapper.xml
@@ -24,4 +24,16 @@
         AND locker_id = #{lockerId}
     </delete>
 
+    <update id="increaseZzimCount">
+        UPDATE Locker
+        SET zzim_count = zzim_count + 1
+        WHERE locker_id = #{lockerId}
+    </update>
+
+    <update id="decreaseZzimCount">
+        UPDATE Locker
+        SET zzim_count = zzim_count - 1
+        WHERE locker_id = #{lockerId} AND zzim_count > 0
+    </update>
+
 </mapper>

--- a/src/main/webapp/WEB-INF/web.xml
+++ b/src/main/webapp/WEB-INF/web.xml
@@ -22,8 +22,12 @@
     <servlet-name>appServlet</servlet-name>
     <servlet-class>org.springframework.web.servlet.DispatcherServlet</servlet-class>
     <init-param>
+      <param-name>contextClass</param-name>
+      <param-value>org.springframework.web.context.support.AnnotationConfigWebApplicationContext</param-value>
+    </init-param>
+    <init-param>
       <param-name>contextConfigLocation</param-name>
-      <param-value>/WEB-INF/spring/appServlet/servlet-context.xml</param-value>
+      <param-value>com.airbng.config.WebConfig</param-value>
     </init-param>
     <load-on-startup>1</load-on-startup>
   </servlet>

--- a/src/test/java/com/airbng/interceptor/RedisRateLimitInterceptorTest.java
+++ b/src/test/java/com/airbng/interceptor/RedisRateLimitInterceptorTest.java
@@ -1,0 +1,93 @@
+// 테스트용 인터셉터 테스트 클래스 예시
+package com.airbng.interceptor;
+
+import com.airbng.common.response.BaseResponse;
+import com.airbng.interceptor.dto.SimpleBaseResponse;
+import com.airbng.util.SessionUtils;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.mock.web.MockHttpSession;
+
+import java.util.concurrent.TimeUnit;
+
+import static com.airbng.common.response.status.BaseResponseStatus.REQUEST_RATE_LIMIT_EXCEEDED;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+class RedisRateLimitInterceptorTest {
+
+    @Mock
+    private StringRedisTemplate redisTemplate;
+
+    @Mock
+    private ValueOperations<String, String> valueOperations;
+
+    @InjectMocks
+    private RedisRateLimitInterceptor interceptor;
+
+    public RedisRateLimitInterceptorTest() {
+        MockitoAnnotations.openMocks(this);
+    }
+
+    @Nested
+    @DisplayName("Redis Rate Limit 테스트")
+    class RateLimit {
+
+        @Test
+        @DisplayName("첫 요청은 허용되어야 한다")
+        void allow_first_request() throws Exception {
+            // given
+            MockHttpServletRequest request = new MockHttpServletRequest("POST", "/api/test");
+            request.setRemoteAddr("127.0.0.1");
+            MockHttpServletResponse response = new MockHttpServletResponse();
+
+            when(redisTemplate.opsForValue()).thenReturn(valueOperations);
+            when(valueOperations.increment("ratelimit:127.0.0.1")).thenReturn(1L);
+
+            // when
+            boolean allowed = interceptor.preHandle(request, response, null);
+
+            // then
+            assertTrue(allowed);
+            verify(valueOperations).increment("ratelimit:127.0.0.1");
+            verify(redisTemplate).expire("ratelimit:127.0.0.1", 1, TimeUnit.SECONDS);
+        }
+
+        @Test
+        @DisplayName("두 번째 요청은 차단되어야 한다")
+        void block_second_request() throws Exception {
+            // given
+            MockHttpServletRequest request = new MockHttpServletRequest("POST", "/api/test");
+            request.setRemoteAddr("127.0.0.1");
+            MockHttpServletResponse response = new MockHttpServletResponse();
+
+            when(redisTemplate.opsForValue()).thenReturn(valueOperations);
+            when(valueOperations.increment("ratelimit:127.0.0.1")).thenReturn(2L);
+
+            // when
+            boolean allowed = interceptor.preHandle(request, response, null);
+
+            // then
+            assertFalse(allowed);
+            assertEquals(REQUEST_RATE_LIMIT_EXCEEDED.getHttpStatus(), response.getStatus());
+
+            // 응답 본문 메시지 검증
+            String content = response.getContentAsString();
+            ObjectMapper objectMapper = new ObjectMapper();
+            SimpleBaseResponse parsed = objectMapper.readValue(content, SimpleBaseResponse.class);
+
+            assertEquals(REQUEST_RATE_LIMIT_EXCEEDED.getMessage(), parsed.getMessage());
+            System.out.println("응답 메세지: " + parsed.getMessage());
+        }
+
+    }
+}

--- a/src/test/java/com/airbng/interceptor/RequestRateLimitInterceptorTest.java
+++ b/src/test/java/com/airbng/interceptor/RequestRateLimitInterceptorTest.java
@@ -1,0 +1,112 @@
+package com.airbng.interceptor;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.mock.web.MockHttpSession;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class RequestRateLimitInterceptorTest {
+
+    private final RequestRateLimitInterceptor interceptor = new RequestRateLimitInterceptor();
+
+    @Nested
+    @DisplayName("첫 요청 허용 테스트")
+    class 첫_요청_테스트 {
+
+        @Test
+        @DisplayName("첫 요청은 허용되어야 한다")
+        void 첫_요청은_허용된다() throws Exception {
+            // given
+            MockHttpServletRequest request = new MockHttpServletRequest();
+            request.setRequestURI("/zzim/toggle");
+            request.setRemoteAddr("127.0.0.1");
+            MockHttpServletResponse response = new MockHttpServletResponse();
+
+            // when
+            boolean result = interceptor.preHandle(request, response, new Object());
+
+            // then
+            assertTrue(result);
+            assertEquals(200, response.getStatus());
+        }
+    }
+
+    @Nested
+    @DisplayName("IP 기반 중복 요청 차단")
+    class 비로그인_사용자_IP기반_차단 {
+
+        @Test
+        @DisplayName("너무 빠른 중복 요청은 차단되어야 한다")
+        void 빠른_중복_요청은_차단된다() throws Exception {
+            // given
+            MockHttpServletRequest request = new MockHttpServletRequest();
+            request.setRequestURI("/zzim/toggle");
+            request.setRemoteAddr("127.0.0.1");
+            MockHttpServletResponse response1 = new MockHttpServletResponse();
+            MockHttpServletResponse response2 = new MockHttpServletResponse();
+
+            // when
+            boolean first = interceptor.preHandle(request, response1, new Object());
+            boolean second = interceptor.preHandle(request, response2, new Object());
+
+            // then
+            assertTrue(first);
+            assertFalse(second);
+            assertEquals(429, response2.getStatus());
+        }
+    }
+
+    @Nested
+    @DisplayName("로그인 사용자 기준 요청 제한")
+    class 로그인_사용자_기반_요청_제한 {
+
+        @Test
+        @DisplayName("로그인한 사용자의 첫 요청은 통과된다")
+        void 로그인한_사용자의_첫_요청은_허용된다() throws Exception {
+            // given
+            MockHttpServletRequest request = new MockHttpServletRequest("POST", "/zzim/lockers/1/members/42");
+            MockHttpSession session = new MockHttpSession();
+            session.setAttribute("memberId", 42L);
+            request.setSession(session);
+            MockHttpServletResponse response = new MockHttpServletResponse();
+
+            // when
+            boolean result = interceptor.preHandle(request, response, new Object());
+
+            // then
+            assertTrue(result);
+            assertEquals(200, response.getStatus());
+        }
+    }
+
+    @Nested
+    @DisplayName("URI + 사용자 기준 DDOS 방어")
+    class URI_사용자_기반_DDOS_방지 {
+
+        @Test
+        @DisplayName("같은 사용자가 동일 URI에 대해 5초 이내 두 번 요청하면 차단된다")
+        void 동일_사용자의_빠른_요청은_차단된다() throws Exception {
+            // given
+            MockHttpServletRequest request = new MockHttpServletRequest("POST", "/lockers/1/members/42/zzim");
+            MockHttpSession session = new MockHttpSession();
+            session.setAttribute("memberId", 42L);
+            request.setSession(session);
+
+            MockHttpServletResponse response1 = new MockHttpServletResponse();
+            MockHttpServletResponse response2 = new MockHttpServletResponse();
+
+            // when
+            boolean allowed1 = interceptor.preHandle(request, response1, new Object());
+            boolean allowed2 = interceptor.preHandle(request, response2, new Object());
+
+            // then
+            assertTrue(allowed1);
+            assertFalse(allowed2);
+            assertEquals(429, response2.getStatus());
+        }
+    }
+}

--- a/src/test/java/com/airbng/interceptor/RequestRateLimitInterceptorTest.java
+++ b/src/test/java/com/airbng/interceptor/RequestRateLimitInterceptorTest.java
@@ -1,6 +1,6 @@
 package com.airbng.interceptor;
 
-import com.airbng.common.response.status.BaseResponseStatus;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -8,108 +8,119 @@ import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.mock.web.MockHttpSession;
 
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneId;
+
 import static com.airbng.common.response.status.BaseResponseStatus.DDOS_PREVENTION;
-import static com.airbng.common.response.status.BaseResponseStatus.SUCCESS;
 import static org.junit.jupiter.api.Assertions.*;
 
 class RequestRateLimitInterceptorTest {
 
-    private final RequestRateLimitInterceptor interceptor = new RequestRateLimitInterceptor();
+    private RequestRateLimitInterceptor interceptor;
+    private MutableClock clock;
+
+    @BeforeEach
+    void setUp() {
+        clock = new MutableClock();
+        interceptor = new RequestRateLimitInterceptor(clock);
+    }
 
     @Nested
-    @DisplayName("첫 요청 허용 테스트")
-    class 첫_요청_테스트 {
+    @DisplayName("기본 요청 허용 테스트")
+    class 기본_요청_테스트 {
 
         @Test
         @DisplayName("첫 요청은 허용되어야 한다")
         void 첫_요청은_허용된다() throws Exception {
-            // given
-            MockHttpServletRequest request = new MockHttpServletRequest();
-            request.setRequestURI("/zzim/toggle");
+            MockHttpServletRequest request = new MockHttpServletRequest("POST", "/zzim/toggle");
             request.setRemoteAddr("127.0.0.1");
             MockHttpServletResponse response = new MockHttpServletResponse();
 
-            // when
             boolean result = interceptor.preHandle(request, response, new Object());
 
-            // then
             assertTrue(result);
-            assertEquals(SUCCESS.getHttpStatus(), response.getStatus());
         }
     }
 
     @Nested
-    @DisplayName("IP 기반 중복 요청 차단")
-    class 비로그인_사용자_IP기반_차단 {
+    @DisplayName("연속 요청 차단 테스트")
+    class 연속_요청_차단 {
 
         @Test
-        @DisplayName("너무 빠른 중복 요청은 차단되어야 한다")
-        void 빠른_중복_요청은_차단된다() throws Exception {
-            // given
-            MockHttpServletRequest request = new MockHttpServletRequest();
-            request.setRequestURI("/zzim/toggle");
-            request.setRemoteAddr("127.0.0.1");
-            MockHttpServletResponse response1 = new MockHttpServletResponse();
-            MockHttpServletResponse response2 = new MockHttpServletResponse();
-
-            // when
-            boolean first = interceptor.preHandle(request, response1, new Object());
-            boolean second = interceptor.preHandle(request, response2, new Object());
-
-            // then
-            assertTrue(first);
-            assertFalse(second);
-            assertEquals(DDOS_PREVENTION.getHttpStatus(), response2.getStatus());
-        }
-    }
-
-    @Nested
-    @DisplayName("로그인 사용자 기준 요청 제한")
-    class 로그인_사용자_기반_요청_제한 {
-
-        @Test
-        @DisplayName("로그인한 사용자의 첫 요청은 통과된다")
-        void 로그인한_사용자의_첫_요청은_허용된다() throws Exception {
-            // given
-            MockHttpServletRequest request = new MockHttpServletRequest("POST", "/lockers/1/members/42/zzim");
-            MockHttpSession session = new MockHttpSession();
-            session.setAttribute("memberId", 42L);
-            request.setSession(session);
-            MockHttpServletResponse response = new MockHttpServletResponse();
-
-            // when
-            boolean result = interceptor.preHandle(request, response, new Object());
-
-            // then
-            assertTrue(result);
-            assertEquals(SUCCESS.getHttpStatus(), response.getStatus());
-        }
-    }
-
-    @Nested
-    @DisplayName("URI + 사용자 기준 DDOS 방어")
-    class URI_사용자_기반_DDOS_방지 {
-
-        @Test
-        @DisplayName("같은 사용자가 동일 URI에 대해 5초 이내 두 번 요청하면 차단된다")
-        void 동일_사용자의_빠른_요청은_차단된다() throws Exception {
-            // given
+        @DisplayName("동일 사용자 100번 연속 요청 후 차단된다")
+        void 동일_사용자_100번_연속_요청_후_차단() throws Exception {
             MockHttpServletRequest request = new MockHttpServletRequest("POST", "/lockers/1/members/42/zzim");
             MockHttpSession session = new MockHttpSession();
             session.setAttribute("memberId", 42L);
             request.setSession(session);
 
-            MockHttpServletResponse response1 = new MockHttpServletResponse();
-            MockHttpServletResponse response2 = new MockHttpServletResponse();
+            for (int i = 1; i < 101; i++) {
+                boolean result = interceptor.preHandle(request, new MockHttpServletResponse(), new Object());
+                assertTrue(result, "요청 #" + i + " 은 허용되어야 합니다.");
+            }
 
-            // when
-            boolean allowed1 = interceptor.preHandle(request, response1, new Object());
-            boolean allowed2 = interceptor.preHandle(request, response2, new Object());
+            // 101번째는 차단되어야 함
+            MockHttpServletResponse blockedResponse = new MockHttpServletResponse();
+            blockedResponse.setCharacterEncoding("UTF-8");
+            boolean blocked = interceptor.preHandle(request, blockedResponse, new Object());
+            assertFalse(blocked);
+            assertEquals(DDOS_PREVENTION.getHttpStatus(), blockedResponse.getStatus());
+            assertEquals("요청이 너무 많습니다. 30초 동안 차단됩니다.", blockedResponse.getContentAsString());
+        }
+    }
 
-            // then
-            assertTrue(allowed1);
-            assertFalse(allowed2);
-            assertEquals(DDOS_PREVENTION.getHttpStatus(), response2.getStatus());
+    @Nested
+    @DisplayName("차단 해제 테스트")
+    class 차단_해제_테스트 {
+
+        @Test
+        @DisplayName("30초가 지나면 차단 해제되어 다시 요청 가능하다")
+        void 차단_후_30초_경과_후_해제() throws Exception {
+            MockHttpServletRequest request = new MockHttpServletRequest("POST", "/lockers/1/members/42/zzim");
+            MockHttpSession session = new MockHttpSession();
+            session.setAttribute("memberId", 42L);
+            request.setSession(session);
+
+            for (int i = 0; i < 100; i++) {
+                interceptor.preHandle(request, new MockHttpServletResponse(), new Object());
+            }
+
+            MockHttpServletResponse blocked = new MockHttpServletResponse();
+            interceptor.preHandle(request, blocked, new Object());
+
+            clock.forward(31000); // 31초 지난 것으로 설정
+
+            MockHttpServletRequest newRequest = new MockHttpServletRequest("POST", "/lockers/1/members/42/zzim");
+            newRequest.setSession(session);
+            MockHttpServletResponse responseAfterBlock = new MockHttpServletResponse();
+
+            boolean allowed = interceptor.preHandle(newRequest, responseAfterBlock, new Object());
+
+            assertTrue(allowed);
+        }
+    }
+
+    static class MutableClock extends Clock {
+        private long millis = System.currentTimeMillis();
+
+        public void forward(long millisToAdd) {
+            this.millis += millisToAdd;
+        }
+
+        @Override
+        public ZoneId getZone() {
+            return ZoneId.systemDefault();
+        }
+
+        @Override
+        public Clock withZone(ZoneId zone) {
+            return this;
+        }
+
+        @Override
+        public Instant instant() {
+            return Instant.ofEpochMilli(millis);
         }
     }
 }

--- a/src/test/java/com/airbng/interceptor/RequestRateLimitInterceptorTest.java
+++ b/src/test/java/com/airbng/interceptor/RequestRateLimitInterceptorTest.java
@@ -1,5 +1,6 @@
 package com.airbng.interceptor;
 
+import com.airbng.common.response.status.BaseResponseStatus;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -7,6 +8,8 @@ import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.mock.web.MockHttpSession;
 
+import static com.airbng.common.response.status.BaseResponseStatus.DDOS_PREVENTION;
+import static com.airbng.common.response.status.BaseResponseStatus.SUCCESS;
 import static org.junit.jupiter.api.Assertions.*;
 
 class RequestRateLimitInterceptorTest {
@@ -31,7 +34,7 @@ class RequestRateLimitInterceptorTest {
 
             // then
             assertTrue(result);
-            assertEquals(200, response.getStatus());
+            assertEquals(SUCCESS.getHttpStatus(), response.getStatus());
         }
     }
 
@@ -56,7 +59,7 @@ class RequestRateLimitInterceptorTest {
             // then
             assertTrue(first);
             assertFalse(second);
-            assertEquals(429, response2.getStatus());
+            assertEquals(DDOS_PREVENTION.getHttpStatus(), response2.getStatus());
         }
     }
 
@@ -68,7 +71,7 @@ class RequestRateLimitInterceptorTest {
         @DisplayName("로그인한 사용자의 첫 요청은 통과된다")
         void 로그인한_사용자의_첫_요청은_허용된다() throws Exception {
             // given
-            MockHttpServletRequest request = new MockHttpServletRequest("POST", "/zzim/lockers/1/members/42");
+            MockHttpServletRequest request = new MockHttpServletRequest("POST", "/lockers/1/members/42/zzim");
             MockHttpSession session = new MockHttpSession();
             session.setAttribute("memberId", 42L);
             request.setSession(session);
@@ -79,7 +82,7 @@ class RequestRateLimitInterceptorTest {
 
             // then
             assertTrue(result);
-            assertEquals(200, response.getStatus());
+            assertEquals(SUCCESS.getHttpStatus(), response.getStatus());
         }
     }
 
@@ -106,7 +109,7 @@ class RequestRateLimitInterceptorTest {
             // then
             assertTrue(allowed1);
             assertFalse(allowed2);
-            assertEquals(429, response2.getStatus());
+            assertEquals(DDOS_PREVENTION.getHttpStatus(), response2.getStatus());
         }
     }
 }

--- a/src/test/java/com/airbng/interceptor/dto/SimpleBaseResponse.java
+++ b/src/test/java/com/airbng/interceptor/dto/SimpleBaseResponse.java
@@ -1,0 +1,11 @@
+package com.airbng.interceptor.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class SimpleBaseResponse {
+    private int code;
+    private String message;
+}

--- a/src/test/java/com/airbng/service/ZzimServiceTest.java
+++ b/src/test/java/com/airbng/service/ZzimServiceTest.java
@@ -36,11 +36,13 @@ class ZzimServiceTest {
     @InjectMocks
     private ZzimServiceImpl zzimService;
 
+    private Long sessionMemberId;
     private Long memberId;
     private Long lockerId;
 
     @BeforeEach
     void setUp() {
+        sessionMemberId = 1L;
         memberId = 1L;
         lockerId = 100L;
     }
@@ -57,7 +59,7 @@ class ZzimServiceTest {
             when(lockerMapper.isLockerKeeper(lockerId, memberId)).thenReturn(false);
             when(zzimMapper.isExistZzim(memberId, lockerId)).thenReturn(0);
 
-            BaseResponseStatus result = zzimService.toggleZzim(memberId, lockerId);
+            BaseResponseStatus result = zzimService.toggleZzim(sessionMemberId, memberId, lockerId);
 
             verify(zzimMapper).insertZzim(memberId, lockerId);
             assertEquals(SUCCESS_INSERT_ZZIM, result);
@@ -71,7 +73,7 @@ class ZzimServiceTest {
             when(lockerMapper.isLockerKeeper(lockerId, memberId)).thenReturn(false);
             when(zzimMapper.isExistZzim(memberId, lockerId)).thenReturn(1);
 
-            BaseResponseStatus result = zzimService.toggleZzim(memberId, lockerId);
+            BaseResponseStatus result = zzimService.toggleZzim(sessionMemberId, memberId, lockerId);
 
             verify(zzimMapper).deleteZzim(memberId, lockerId);
             assertEquals(SUCCESS_DELETE_ZZIM, result);
@@ -83,7 +85,7 @@ class ZzimServiceTest {
             when(memberMapper.isExistMember(memberId)).thenReturn(false);
 
             MemberException ex = assertThrows(MemberException.class,
-                    () -> zzimService.toggleZzim(memberId, lockerId));
+                    () -> zzimService.toggleZzim(sessionMemberId, memberId, lockerId));
 
             assertEquals(NOT_FOUND_MEMBER, ex.getBaseResponseStatus());
         }
@@ -95,7 +97,7 @@ class ZzimServiceTest {
             when(lockerMapper.isExistLocker(lockerId)).thenReturn(false);
 
             LockerException ex = assertThrows(LockerException.class,
-                    () -> zzimService.toggleZzim(memberId, lockerId));
+                    () -> zzimService.toggleZzim(sessionMemberId, memberId, lockerId));
 
             assertEquals(NOT_FOUND_LOCKER, ex.getBaseResponseStatus());
         }
@@ -108,7 +110,7 @@ class ZzimServiceTest {
             when(lockerMapper.isLockerKeeper(lockerId, memberId)).thenReturn(true);
 
             ZzimException ex = assertThrows(ZzimException.class,
-                    () -> zzimService.toggleZzim(memberId, lockerId));
+                    () -> zzimService.toggleZzim(sessionMemberId, memberId, lockerId));
 
             assertEquals(SELF_LOCKER_ZZIM, ex.getBaseResponseStatus());
         }
@@ -123,7 +125,7 @@ class ZzimServiceTest {
             doThrow(new DuplicateKeyException("중복")).when(zzimMapper).insertZzim(memberId, lockerId);
 
             ZzimException ex = assertThrows(ZzimException.class,
-                    () -> zzimService.toggleZzim(memberId, lockerId));
+                    () -> zzimService.toggleZzim(sessionMemberId, memberId, lockerId));
 
             assertEquals(DUPLICATE_ZZIM, ex.getBaseResponseStatus());
         }

--- a/src/test/java/com/airbng/service/ZzimServiceTest.java
+++ b/src/test/java/com/airbng/service/ZzimServiceTest.java
@@ -1,0 +1,150 @@
+package com.airbng.service;
+
+import com.airbng.common.exception.MemberException;
+import com.airbng.common.exception.LockerException;
+import com.airbng.common.exception.ZzimException;
+import com.airbng.common.response.status.BaseResponseStatus;
+import com.airbng.mappers.LockerMapper;
+import com.airbng.mappers.MemberMapper;
+import com.airbng.mappers.ZzimMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.dao.DuplicateKeyException;
+
+import static com.airbng.common.response.status.BaseResponseStatus.*;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class ZzimServiceTest {
+
+    @Mock
+    private ZzimMapper zzimMapper;
+
+    @Mock
+    private MemberMapper memberMapper;
+
+    @Mock
+    private LockerMapper lockerMapper;
+
+    @InjectMocks
+    private ZzimServiceImpl zzimService;
+
+    private Long memberId;
+    private Long lockerId;
+
+    @BeforeEach
+    void setUp() {
+        memberId = 1L;
+        lockerId = 100L;
+    }
+
+    @Nested
+    @DisplayName("찜 등록/취소 테스트")
+    class ToggleZzim {
+
+        @Test
+        @DisplayName("아직 찜하지 않은 경우 → 등록 수행")
+        void 아직_찜하지_않은_경우_등록() {
+            when(memberMapper.isExistMember(memberId)).thenReturn(true);
+            when(lockerMapper.isExistLocker(lockerId)).thenReturn(true);
+            when(lockerMapper.isLockerKeeper(lockerId, memberId)).thenReturn(false);
+            when(zzimMapper.isExistZzim(memberId, lockerId)).thenReturn(0);
+
+            BaseResponseStatus result = zzimService.toggleZzim(memberId, lockerId);
+
+            verify(zzimMapper).insertZzim(memberId, lockerId);
+            assertEquals(SUCCESS_INSERT_ZZIM, result);
+        }
+
+        @Test
+        @DisplayName("이미 찜한 경우 → 삭제 수행")
+        void 이미_찜한_경우_삭제() {
+            when(memberMapper.isExistMember(memberId)).thenReturn(true);
+            when(lockerMapper.isExistLocker(lockerId)).thenReturn(true);
+            when(lockerMapper.isLockerKeeper(lockerId, memberId)).thenReturn(false);
+            when(zzimMapper.isExistZzim(memberId, lockerId)).thenReturn(1);
+
+            BaseResponseStatus result = zzimService.toggleZzim(memberId, lockerId);
+
+            verify(zzimMapper).deleteZzim(memberId, lockerId);
+            assertEquals(SUCCESS_DELETE_ZZIM, result);
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 멤버")
+        void 존재하지_않는_멤버() {
+            when(memberMapper.isExistMember(memberId)).thenReturn(false);
+
+            MemberException ex = assertThrows(MemberException.class,
+                    () -> zzimService.toggleZzim(memberId, lockerId));
+
+            assertEquals(NOT_FOUND_MEMBER, ex.getBaseResponseStatus());
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 락커")
+        void 존재하지_않는_락커() {
+            when(memberMapper.isExistMember(memberId)).thenReturn(true);
+            when(lockerMapper.isExistLocker(lockerId)).thenReturn(false);
+
+            LockerException ex = assertThrows(LockerException.class,
+                    () -> zzimService.toggleZzim(memberId, lockerId));
+
+            assertEquals(NOT_FOUND_LOCKER, ex.getBaseResponseStatus());
+        }
+
+        @Test
+        @DisplayName("본인 락커 찜 시도")
+        void 본인_락커_찜_시도() {
+            when(memberMapper.isExistMember(memberId)).thenReturn(true);
+            when(lockerMapper.isExistLocker(lockerId)).thenReturn(true);
+            when(lockerMapper.isLockerKeeper(lockerId, memberId)).thenReturn(true);
+
+            ZzimException ex = assertThrows(ZzimException.class,
+                    () -> zzimService.toggleZzim(memberId, lockerId));
+
+            assertEquals(SELF_LOCKER_ZZIM, ex.getBaseResponseStatus());
+        }
+
+        @Test
+        @DisplayName("중복 찜 등록 시 예외 발생")
+        void 중복_찜등록_예외() {
+            when(memberMapper.isExistMember(memberId)).thenReturn(true);
+            when(lockerMapper.isExistLocker(lockerId)).thenReturn(true);
+            when(lockerMapper.isLockerKeeper(lockerId, memberId)).thenReturn(false);
+            when(zzimMapper.isExistZzim(memberId, lockerId)).thenReturn(0);
+            doThrow(new DuplicateKeyException("중복")).when(zzimMapper).insertZzim(memberId, lockerId);
+
+            ZzimException ex = assertThrows(ZzimException.class,
+                    () -> zzimService.toggleZzim(memberId, lockerId));
+
+            assertEquals(DUPLICATE_ZZIM, ex.getBaseResponseStatus());
+        }
+    }
+
+    @Nested
+    @DisplayName("찜 여부 확인 테스트")
+    class isExsistZzimTest {
+
+        @Test
+        @DisplayName("찜 존재 확인: true")
+        void 찜_존재() {
+            when(zzimMapper.isExistZzim(memberId, lockerId)).thenReturn(1);
+            assertTrue(zzimService.isExistZzim(memberId, lockerId));
+        }
+
+        @Test
+        @DisplayName("찜 존재 확인: false")
+        void 찜_존재하지_않음() {
+            when(zzimMapper.isExistZzim(memberId, lockerId)).thenReturn(0);
+            assertFalse(zzimService.isExistZzim(memberId, lockerId));
+        }
+    }
+}

--- a/src/test/java/com/airbng/util/SessionUtilsTest.java
+++ b/src/test/java/com/airbng/util/SessionUtilsTest.java
@@ -1,0 +1,101 @@
+package com.airbng.util;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpSession;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class SessionUtilsTest {
+
+    @Nested
+    @DisplayName("getMemberId 메서드 테스트")
+    class GetMemberIdTest {
+
+        @Test
+        @DisplayName("세션에 memberId가 존재할 경우 정상 반환")
+        void memberId_정상반환() {
+            // given
+            MockHttpServletRequest request = new MockHttpServletRequest();
+            MockHttpSession session = new MockHttpSession();
+            session.setAttribute("memberId", 123L);
+            request.setSession(session);
+
+            // when
+            Long result = SessionUtils.getMemberId(request);
+
+            // then
+            assertEquals(123L, result);
+        }
+
+        @Test
+        @DisplayName("세션이 없을 경우 null 반환")
+        void 세션없음_null반환() {
+            // given
+            MockHttpServletRequest request = new MockHttpServletRequest();
+
+            // when
+            Long result = SessionUtils.getMemberId(request);
+
+            // then
+            assertNull(result);
+        }
+
+        @Test
+        @DisplayName("세션은 있지만 memberId가 없을 경우 null 반환")
+        void memberId_없음_null반환() {
+            // given
+            MockHttpServletRequest request = new MockHttpServletRequest();
+            request.setSession(new MockHttpSession()); // 빈 세션
+
+            // when
+            Long result = SessionUtils.getMemberId(request);
+
+            // then
+            assertNull(result);
+        }
+
+        @Test
+        @DisplayName("memberId가 Long이 아닐 경우 null 반환")
+        void memberId_타입불일치_null반환() {
+            // given
+            MockHttpServletRequest request = new MockHttpServletRequest();
+            MockHttpSession session = new MockHttpSession();
+            session.setAttribute("memberId", "not-a-long"); // 잘못된 타입
+            request.setSession(session);
+
+            // when
+            Long result = SessionUtils.getMemberId(request);
+
+            // then
+            assertNull(result);
+        }
+    }
+
+    @Nested
+    @DisplayName("isLoggedIn 메서드 테스트")
+    class IsLoggedInTest {
+
+        @Test
+        @DisplayName("memberId가 존재할 경우 true")
+        void 로그인된_상태_true() {
+            MockHttpServletRequest request = new MockHttpServletRequest();
+            MockHttpSession session = new MockHttpSession();
+            session.setAttribute("memberId", 1L);
+            request.setSession(session);
+
+            assertTrue(SessionUtils.isLoggedIn(request));
+        }
+
+        @Test
+        @DisplayName("memberId가 없을 경우 false")
+        void 로그인_안됨_false() {
+            MockHttpServletRequest request = new MockHttpServletRequest();
+            request.setSession(new MockHttpSession());
+
+            assertFalse(SessionUtils.isLoggedIn(request));
+        }
+    }
+}


### PR DESCRIPTION
## 요약 (Summary)
- [x] 찜 등록/취소 기능 
- [x] 찜 100번 이상 연속으로 요청 시 30초 차단
- [x] 로그인 5번 이상 연속으로 요청 시 너무 많은 요청으로 차단 (일단 5번)

## 🔑 변경 사항 (Key Changes)

- Zzim table 추가
- Locker table에 zzim_count 컬럼 추가
- 찜 100번 이상 연속 요청 시 30초동안 차단
- 로그인 5번 이상 연속 요청 시 차단

## 📝 리뷰 요구사항 (To Reviewers)

- [ ] 자신이 올린 보관소는 찜 등록/취소 불가능 (메시지 잘 뜨는지)
- [x] 사용자가 찜 할 시 찜 존재 여부 먼저 확인 후 없으면 등록 있으면 취소 DB에 잘 반영 되는지!
- [x] 찜 등록/취소 100번 이상 요청 시 차단 잘 되는지
- [ ] 로그인 5번 이상 요청 시 차단 잘 되는지
- [x] Redis 연결 잘 되는지

## 확인 방법 

### DB 변경 해야함! (Zzim table 추가 & Locker table zzim_count 컬럼 추가)
https://www.notion.so/ERD-ddl-210f2e4da30b8180accae11b53d665fb

### ```application.properties``` 파일 ```resources``` 폴더에 추가 => 안 하면 서버 시작 시 Redis 연결 안 됐다고 오류남
https://www.notion.so/application-properties-222f2e4da30b800b994bc25ebac80425

### 반드시 로그인 후 로그인 한 id 값으로 찜 등록/취소 해야합니다 ~~ (Postman으로 고고!)

### 찜 등록/취소 100번 이상 확인하는 방법
![image](https://github.com/user-attachments/assets/66fbb8c5-c1cf-4449-b9ad-aa5827670e0a)

### 로그인은 6번 눌러보세요!! (콘솔로도 확인 가능)

성공 시
- 찜 등록/취소 성공 (처음 누르면 찜 등록, 한번 더 누를 시 찜 취소)
![image](https://github.com/user-attachments/assets/1ca512ee-8910-403c-8b6e-e295cb084b1f)
![image](https://github.com/user-attachments/assets/ddf37319-1f53-4193-b068-cbfd6eb754f3)

- 찜 100번 이상 요청 시
![image](https://github.com/user-attachments/assets/107cb507-656d-4992-b3bb-bae2d3d181d6)

- 로그인 5번 이상 즉 6번 요청 시
![image](https://github.com/user-attachments/assets/56622c81-3ddc-46ef-bcc3-a2f4ba837d20)