### PR TITLE
[#49] BE 예약 폼 받아오기

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,4 @@ build/
 src/main/resources/db.properties
 src/main/resources/s3.properties
 src/main/resources/application.yml
+src/main/resources/application.properties

--- a/src/main/java/com/airbng/common/response/status/BaseResponseStatus.java
+++ b/src/main/java/com/airbng/common/response/status/BaseResponseStatus.java
@@ -39,6 +39,8 @@ public enum BaseResponseStatus implements ResponseStatus{
     NOT_FOUND_LOCKERDETAILS(3002,HttpStatus.BAD_REQUEST.value(), "락커를 찾을 수 없습니다."),
     MEMBER_ALREADY_HAS_LOCKER(3003, HttpStatus.BAD_REQUEST.value(), "한 멤버당 하나의 보관소만 등록할 수 있습니다."),
     LOCKER_KEEPER_MISMATCH(3004, HttpStatus.BAD_REQUEST.value(), "선택한 보관소의 보관자 정보가 일치하지 않습니다."),
+    LOCKER_NOT_AVAILABLE(3005, HttpStatus.LOCKED.value(), "비활성화된 보관소입니다."),
+
     /**
      * 4000 예약 관련 코드
      */

--- a/src/main/java/com/airbng/controller/ReservationController.java
+++ b/src/main/java/com/airbng/controller/ReservationController.java
@@ -4,6 +4,7 @@ import com.airbng.common.response.BaseResponse;
 import com.airbng.domain.base.ReservationState;
 import com.airbng.dto.reservation.*;
 import com.airbng.service.ReservationService;
+import com.airbng.util.SessionUtils;
 import lombok.RequiredArgsConstructor;
 import org.springframework.validation.annotation.Validated;
 import lombok.extern.slf4j.Slf4j;
@@ -39,7 +40,9 @@ public class ReservationController {
 
     // 예약 등록
     @PostMapping
-    public BaseResponse<String> insertReservation(@RequestBody @Valid ReservationInsertRequest request) {
+    public BaseResponse<String> insertReservation(@RequestBody @Valid ReservationInsertRequest request,
+                                                  HttpSession session) {
+        request.setDropperId(SessionUtils.getLoginMemberId(session));
         return new BaseResponse<>(reservationService.insertReservation(request));
     }
 

--- a/src/main/java/com/airbng/controller/ReservationController.java
+++ b/src/main/java/com/airbng/controller/ReservationController.java
@@ -38,6 +38,12 @@ public class ReservationController {
         return new BaseResponse<>(reservationService.updateReservationState(reservationId, memberId));
     }
 
+    // 예약 폼 받아오기
+    @GetMapping("/form")
+    public BaseResponse<ReservationFormResponse> getReservationForm(@RequestParam("lockerId") @Min(1) @NotNull Long lockerId) {
+        return new BaseResponse<>(reservationService.getReservationForm(lockerId));
+    }
+
     // 예약 등록
     @PostMapping
     public BaseResponse<String> insertReservation(@RequestBody @Valid ReservationInsertRequest request,

--- a/src/main/java/com/airbng/dto/jimType/JimTypeCountResult.java
+++ b/src/main/java/com/airbng/dto/jimType/JimTypeCountResult.java
@@ -5,11 +5,16 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 
+import javax.validation.constraints.Min;
+import javax.validation.constraints.NotNull;
+
 @Getter
 @Setter
 @NoArgsConstructor
 @AllArgsConstructor
 public class JimTypeCountResult {
+    @NotNull @Min(1)
     public Long jimTypeId; // 맡길 짐 타입 ID
+    @NotNull @Min(1)
     public Long count; // 몇개
 }

--- a/src/main/java/com/airbng/dto/jimType/LockerJimTypeResult.java
+++ b/src/main/java/com/airbng/dto/jimType/LockerJimTypeResult.java
@@ -1,0 +1,19 @@
+package com.airbng.dto.jimType;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import javax.validation.constraints.Min;
+import javax.validation.constraints.NotNull;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class LockerJimTypeResult { // 보관소가 관리하는 짐 타입
+    private Long jimTypeId;
+    private String typeName;
+    private Long pricePerHour;
+}

--- a/src/main/java/com/airbng/dto/jimType/LockerJimTypeResult.java
+++ b/src/main/java/com/airbng/dto/jimType/LockerJimTypeResult.java
@@ -1,9 +1,7 @@
 package com.airbng.dto.jimType;
 
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
+import com.airbng.domain.jimtype.LockerJimType;
+import lombok.*;
 
 import javax.validation.constraints.Min;
 import javax.validation.constraints.NotNull;
@@ -12,8 +10,18 @@ import javax.validation.constraints.NotNull;
 @Setter
 @NoArgsConstructor
 @AllArgsConstructor
+@Builder
 public class LockerJimTypeResult { // 보관소가 관리하는 짐 타입
     private Long jimTypeId;
     private String typeName;
     private Long pricePerHour;
+
+    public static LockerJimTypeResult from(LockerJimType lockerJimType){
+        return LockerJimTypeResult.builder()
+                .jimTypeId(lockerJimType.getJimType().getJimTypeId())
+                .typeName(lockerJimType.getJimType().getTypeName())
+                .pricePerHour(lockerJimType.getJimType().getPricePerHour())
+                .build();
+    }
+
 }

--- a/src/main/java/com/airbng/dto/reservation/ReservationFormResponse.java
+++ b/src/main/java/com/airbng/dto/reservation/ReservationFormResponse.java
@@ -1,0 +1,17 @@
+package com.airbng.dto.reservation;
+
+import com.airbng.dto.jimType.LockerJimTypeResult;
+import lombok.*;
+
+import java.util.List;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class ReservationFormResponse {
+    private Long lockerId;
+    private String lockerName;
+    private String addressKr;
+    private List<LockerJimTypeResult> lockerJimTypes;
+}

--- a/src/main/java/com/airbng/dto/reservation/ReservationFormResponse.java
+++ b/src/main/java/com/airbng/dto/reservation/ReservationFormResponse.java
@@ -1,17 +1,29 @@
 package com.airbng.dto.reservation;
 
+import com.airbng.domain.Locker;
+import com.airbng.domain.Reservation;
 import com.airbng.dto.jimType.LockerJimTypeResult;
 import lombok.*;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Getter
 @Setter
 @NoArgsConstructor
 @AllArgsConstructor
+@Builder
 public class ReservationFormResponse {
     private Long lockerId;
     private String lockerName;
     private String addressKr;
     private List<LockerJimTypeResult> lockerJimTypes;
+
+    public static ReservationFormResponse from(Locker locker){
+        return ReservationFormResponse.builder()
+                .lockerName(locker.getLockerName())
+                .lockerId(locker.getLockerId())
+                .addressKr(locker.getAddress() + " " +locker.getAddressDetail())
+                .build();
+    }
 }

--- a/src/main/java/com/airbng/dto/reservation/ReservationInsertRequest.java
+++ b/src/main/java/com/airbng/dto/reservation/ReservationInsertRequest.java
@@ -19,11 +19,11 @@ public class ReservationInsertRequest {
     @JsonIgnore
     private Long id;
 
-    @NotNull @Min(1)
-    private Long keeperId;  // 맡길 짐을 보관하는 사람 ID
     @JsonIgnore
     private Long dropperId;
 
+    @JsonIgnore
+    private Long keeperId;
 
     @NotNull @Min(1)
     private Long lockerId;  // 맡길 짐을 보관하는 락커 ID

--- a/src/main/java/com/airbng/dto/reservation/ReservationInsertRequest.java
+++ b/src/main/java/com/airbng/dto/reservation/ReservationInsertRequest.java
@@ -20,10 +20,10 @@ public class ReservationInsertRequest {
     private Long id;
 
     @NotNull @Min(1)
-    private Long dropperId; // 맡길 사람 ID
-    
-    @NotNull @Min(1)
     private Long keeperId;  // 맡길 짐을 보관하는 사람 ID
+    @JsonIgnore
+    private Long dropperId;
+
 
     @NotNull @Min(1)
     private Long lockerId;  // 맡길 짐을 보관하는 락커 ID

--- a/src/main/java/com/airbng/dto/reservation/ReservationInsertRequest.java
+++ b/src/main/java/com/airbng/dto/reservation/ReservationInsertRequest.java
@@ -3,7 +3,9 @@ package com.airbng.dto.reservation;
 import com.airbng.dto.jimType.JimTypeCountResult;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import lombok.*;
+import org.springframework.format.annotation.DateTimeFormat;
 
+import javax.validation.Valid;
 import javax.validation.constraints.Min;
 import javax.validation.constraints.NotNull;
 import java.util.List;
@@ -26,12 +28,12 @@ public class ReservationInsertRequest {
     @NotNull @Min(1)
     private Long lockerId;  // 맡길 짐을 보관하는 락커 ID
 
-    @NotNull
+    @NotNull @DateTimeFormat(pattern = "yyyy-mm-dd HH:mm:ss")
     private String startTime; // 보관 시작 시간
 
-    @NotNull
+    @NotNull @DateTimeFormat(pattern = "yyyy-mm-dd HH:mm:ss")
     private String endTime;   // 회수해갈 시간
 
-    @NotNull
+    @Valid
     private List<JimTypeCountResult> jimTypeCounts; // 맡길 짐 타입과 개수
 }

--- a/src/main/java/com/airbng/mappers/LockerMapper.java
+++ b/src/main/java/com/airbng/mappers/LockerMapper.java
@@ -8,6 +8,7 @@ import com.airbng.dto.jimType.LockerJimTypeResult;
 import com.airbng.dto.locker.LockerDetailResponse;
 import com.airbng.dto.locker.LockerPreviewResult;
 import com.airbng.dto.locker.LockerSearchRequest;
+import com.airbng.dto.reservation.ReservationFormResponse;
 import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Param;
 
@@ -54,6 +55,8 @@ public interface LockerMapper {
     void toggleLockerIsAvailable(@Param("lockerId") Long lockerId);
 
     Available getIsAvailableById(@Param("lockerId") Long lockerId);
+
+    ReservationFormResponse getLockerInfoById(@Param("lockerId") Long lockerId);
 
     List<LockerJimTypeResult> getLockerJimTypeById(@Param("lockerId") Long lockerId);
 }

--- a/src/main/java/com/airbng/mappers/LockerMapper.java
+++ b/src/main/java/com/airbng/mappers/LockerMapper.java
@@ -4,6 +4,7 @@ import com.airbng.domain.Locker;
 import com.airbng.domain.base.Available;
 import com.airbng.domain.base.ReservationState;
 import com.airbng.domain.image.Image;
+import com.airbng.dto.jimType.LockerJimTypeResult;
 import com.airbng.dto.locker.LockerDetailResponse;
 import com.airbng.dto.locker.LockerPreviewResult;
 import com.airbng.dto.locker.LockerSearchRequest;
@@ -53,4 +54,6 @@ public interface LockerMapper {
     void toggleLockerIsAvailable(@Param("lockerId") Long lockerId);
 
     Available getIsAvailableById(@Param("lockerId") Long lockerId);
+
+    List<LockerJimTypeResult> getLockerJimTypeById(@Param("lockerId") Long lockerId);
 }

--- a/src/main/java/com/airbng/mappers/LockerMapper.java
+++ b/src/main/java/com/airbng/mappers/LockerMapper.java
@@ -59,4 +59,6 @@ public interface LockerMapper {
     ReservationFormResponse getLockerInfoById(@Param("lockerId") Long lockerId);
 
     List<LockerJimTypeResult> getLockerJimTypeById(@Param("lockerId") Long lockerId);
+
+    Long getLockerKepperId(@Param("lockerId") Long lockerId);
 }

--- a/src/main/java/com/airbng/service/ReservationService.java
+++ b/src/main/java/com/airbng/service/ReservationService.java
@@ -19,6 +19,9 @@ public interface ReservationService {
     //예약 승인/거절
     ReservationConfirmResponse confirmReservationState(Long reservationId, String approve, Long memberId);
 
+    // 예약 폼 데이터 받아오기
+    ReservationFormResponse getReservationForm(Long lockerId);
+
     // 예약 등록
     BaseResponseStatus insertReservation(ReservationInsertRequest request);
 

--- a/src/main/java/com/airbng/service/ReservationServiceImpl.java
+++ b/src/main/java/com/airbng/service/ReservationServiceImpl.java
@@ -5,9 +5,9 @@ import com.airbng.common.exception.LockerException;
 import com.airbng.common.exception.MemberException;
 import com.airbng.common.exception.ReservationException;
 import com.airbng.common.response.status.BaseResponseStatus;
-import com.airbng.domain.base.ReservationState;
 import com.airbng.domain.Reservation;
 import com.airbng.domain.base.ChargeType;
+import com.airbng.domain.base.ReservationState;
 import com.airbng.dto.jimType.JimTypeCountResult;
 import com.airbng.dto.reservation.*;
 import com.airbng.mappers.JimTypeMapper;
@@ -31,13 +31,13 @@ import static com.airbng.common.response.status.BaseResponseStatus.*;
 @Slf4j
 @Service
 @RequiredArgsConstructor
-public class ReservationServiceImpl implements ReservationService{
-  
+public class ReservationServiceImpl implements ReservationService {
+
     private final ReservationMapper reservationMapper;
     private final JimTypeMapper jimTypeMapper;
     private final MemberMapper memberMapper;
     private final LockerMapper lockerMapper;
-    private static final Long LIMIT= 10L; // 페이지당 최대 예약 개수
+    private static final Long LIMIT = 10L; // 페이지당 최대 예약 개수
 
     //예약 조회 + 페이징 처리
 
@@ -47,7 +47,7 @@ public class ReservationServiceImpl implements ReservationService{
                 memberId, role, state, nextCursorId, LIMIT, period);
 
         // 초기 커서 ID 설정
-        if(nextCursorId == null) {
+        if (nextCursorId == null) {
             nextCursorId = -1L;
         }
 
@@ -105,14 +105,15 @@ public class ReservationServiceImpl implements ReservationService{
             lock.lock();
 
             /** 맴버 존재 유무 파악 */
-            if(!memberMapper.findById(memberId)) throw new MemberException(NOT_FOUND_MEMBER);
+            if (!memberMapper.findById(memberId)) throw new MemberException(NOT_FOUND_MEMBER);
 
             /** 요청 예약건의 존재여부 파악 */
             Reservation reservation = reservationMapper.findReservationWithDropperById(reservationId);
             if (reservation == null) throw new ReservationException(NOT_FOUND_RESERVATION);
 
             /** 예약건의 주인이 맞는지 파악 */
-            if(!reservation.getDropper().getMemberId().equals(memberId)) throw new ReservationException(NOT_DROPPER_OF_RESERVATION);
+            if (!reservation.getDropper().getMemberId().equals(memberId))
+                throw new ReservationException(NOT_DROPPER_OF_RESERVATION);
 
             ChargeType chargeType = ChargeType.from(reservation.getStartTime());
             ReservationState state = reservation.getState();
@@ -121,13 +122,13 @@ public class ReservationServiceImpl implements ReservationService{
             reservationMapper.updateReservationState(reservationId,
                     ReservationState.CANCELLED);
 
-             return ReservationCancelResponse.of(reservation,
-                     chargeType.discountAmount(),ReservationState.CANCELLED);
+            return ReservationCancelResponse.of(reservation,
+                    chargeType.discountAmount(), ReservationState.CANCELLED);
 
-            } finally{
-                /** 무조건 락 해제 */
-                lock.unlock();
-            }
+        } finally {
+            /** 무조건 락 해제 */
+            lock.unlock();
+        }
     }
 
     @Override
@@ -145,7 +146,8 @@ public class ReservationServiceImpl implements ReservationService{
             if (reservation == null) throw new ReservationException(NOT_FOUND_RESERVATION);
 
             //짐을 맡아주는 사람인지 확인
-            if (!reservation.getKeeper().getMemberId().equals(memberId)) throw new ReservationException(NOT_KEEPER_OF_RESERVATION);
+            if (!reservation.getKeeper().getMemberId().equals(memberId))
+                throw new ReservationException(NOT_KEEPER_OF_RESERVATION);
 
             //취소, 완료상태는 상태변경 불가
             reservation.getState().isAvailableUpdate(reservation.getState());
@@ -167,86 +169,74 @@ public class ReservationServiceImpl implements ReservationService{
         }
     }
 
+
+    @Override
+    public ReservationDetailResponse findReservationDetail(Long reservationId, Long memberId) {
+        Reservation reservation = reservationMapper.findReservationDetailById(reservationId);
+        if (reservation == null) throw new ReservationException(NOT_FOUND_RESERVATION); // 보관소 있나요
+        if (!reservation.getDropper().getMemberId().equals(memberId))
+            throw new ReservationException(NOT_DROPPER_OF_RESERVATION); // 있는 보관소가 내거 맞나요
+
+        return ReservationDetailResponse.from(reservation);
+    }
+
     // 예약 등록
     @Override
     @Transactional // 짐타입 등록 실패한 경우 예약 등록까지 롤백
-    public BaseResponseStatus insertReservation(ReservationInsertRequest request) {
+    public BaseResponseStatus insertReservation(final ReservationInsertRequest request) {
         log.info("insertReservation({})", request);
 
-        // startTime과 endTime이 유효한지 확인
-        String startTime = request.getStartTime();
-        String endTime = request.getEndTime();
-        if (request.getStartTime() == null || request.getEndTime() == null) {
-            throw new ReservationException(INVALID_RESERVATION_TIME);
-        }
+        validateStartTimeAndEndTime(request.getStartTime(), request.getEndTime());
+        validateMember(request.getDropperId(), request.getKeeperId());
+        validateLockerKeeper(request.getLockerId(), request.getKeeperId());
+        validateJimTypes(request.getLockerId(), request.getJimTypeCounts());
 
-        if (LocalDateTimeUtils.isStartTimeAfterEndTime(startTime, endTime)
-                || LocalDateTimeUtils.isStartTimeEqualEndTime(startTime, endTime)) {
-            throw new ReservationException(INVALID_RESERVATION_TIME_ORDER);
-        }
-
-        // dropper와 keeper 존재 여부 확인
-        boolean dropperFlag = memberMapper.isExistMember(request.getDropperId());
-        if (!dropperFlag) {
-            throw new MemberException(NOT_FOUND_MEMBER);
-        }
-
-        boolean keeperFlag = memberMapper.isExistMember(request.getKeeperId());
-        if (!keeperFlag) {
-            throw new MemberException(NOT_FOUND_MEMBER);
-        }
-
-        // dropper와 keeper가 동일한 경우 예외
-        if (request.getDropperId().equals(request.getKeeperId())) {
-            throw new ReservationException(INVALID_RESERVATION_PARTICIPANTS);
-        }
-
-        // 락커 존재 여부 확인
-        boolean lockerFlag = lockerMapper.isExistLocker(request.getLockerId());
-        if (!lockerFlag) {
-            throw new LockerException(NOT_FOUND_LOCKER);
-        }
-
-        // keeper가 락커의 소유자인지 확인
-        boolean isLockerKeeper = lockerMapper.isLockerKeeper(request.getLockerId(), request.getKeeperId());
-        if (!isLockerKeeper) {
-            throw new LockerException(LOCKER_KEEPER_MISMATCH);
-        }
-
-        // 예약 엔티티 추가
         reservationMapper.insertReservation(request);
-        Long reservationId = request.getId();
-        if (reservationId == null || reservationId < 1) {
-            throw new ReservationException(CANNOT_CREATE_RESERVATION);
-        }
+        int cnt = jimTypeMapper.insertReservationJimTypes(request.getId(), request.getJimTypeCounts());
 
-        // 해당 보관소가 관리하는 짐타입들인지 검사
-        List<Long> jimTypeIds = request.getJimTypeCounts().stream()
-                .map(JimTypeCountResult::getJimTypeId)
-                .collect(Collectors.toList());
-        boolean validateJimtype = jimTypeMapper.validateLockerJimTypes(request.getLockerId(), jimTypeIds, jimTypeIds.size());
-        if (!validateJimtype) {
-            throw new JimTypeException(LOCKER_DOES_NOT_SUPPORT_JIMTYPE);
-        }
-
-
-        // 위에서 insert한 예약 엔티티에 맞게 짐 타입 등록
-        int cnt = jimTypeMapper.insertReservationJimTypes(reservationId, request.getJimTypeCounts());
-        // 요청한 짐 타입 개수와 실제 등록된 개수가 일치하지 않는 경우 예외
-        // Mapper 에서 메서드가 실패하면 0을 반환
         if (cnt != request.getJimTypeCounts().size()) {
             throw new ReservationException(INVALID_JIMTYPE_COUNT);
         }
 
         return CREATED_RESERVATION;
     }
-    @Override
-    public ReservationDetailResponse findReservationDetail(Long reservationId, Long memberId) {
-        Reservation reservation = reservationMapper.findReservationDetailById(reservationId);
-        if(reservation==null) throw new ReservationException(NOT_FOUND_RESERVATION); // 보관소 있나요
-        if(!reservation.getDropper().getMemberId().equals(memberId)) throw new ReservationException(NOT_DROPPER_OF_RESERVATION); // 있는 보관소가 내거 맞나요
 
-        return ReservationDetailResponse.from(reservation);
+    private static void validateStartTimeAndEndTime(final String startTime, final String endTime) {
+        if (LocalDateTimeUtils.isStartTimeAfterEndTime(startTime, endTime)
+                || LocalDateTimeUtils.isStartTimeEqualEndTime(startTime, endTime)) {
+            throw new ReservationException(INVALID_RESERVATION_TIME_ORDER);
+        }
     }
 
+    private void validateJimTypes(final Long lockerId, final List<JimTypeCountResult> jimTypeCounts) {
+        List<Long> jimTypeIds = jimTypeCounts.stream()
+                .map(JimTypeCountResult::getJimTypeId)
+                .collect(Collectors.toList());
+        if (!jimTypeMapper.validateLockerJimTypes(lockerId, jimTypeIds, jimTypeIds.size())) {
+            throw new JimTypeException(LOCKER_DOES_NOT_SUPPORT_JIMTYPE);
+        }
+    }
+
+    private void validateLockerKeeper(final Long lockerId, final Long keeperId) {
+        if (!lockerMapper.isExistLocker(lockerId)) {
+            throw new LockerException(NOT_FOUND_LOCKER);
+        }
+        if (!lockerMapper.isLockerKeeper(lockerId, keeperId)) {
+            throw new LockerException(LOCKER_KEEPER_MISMATCH);
+        }
+    }
+
+    private void validateMember(final Long dropperId, final Long keeperId) {
+        // dropper와 keeper가 동일한 경우 예외
+        if (dropperId.equals(keeperId)) {
+            throw new ReservationException(INVALID_RESERVATION_PARTICIPANTS);
+        }
+        // dropper와 keeper 존재 여부 확인
+        if (!memberMapper.isExistMember(dropperId)) {
+            throw new MemberException(NOT_FOUND_MEMBER);
+        }
+        if (!memberMapper.isExistMember(keeperId)) {
+            throw new MemberException(NOT_FOUND_MEMBER);
+        }
+    }
 }

--- a/src/main/java/com/airbng/service/ReservationServiceImpl.java
+++ b/src/main/java/com/airbng/service/ReservationServiceImpl.java
@@ -40,7 +40,6 @@ public class ReservationServiceImpl implements ReservationService {
     private static final Long LIMIT = 10L; // 페이지당 최대 예약 개수
 
     //예약 조회 + 페이징 처리
-
     @Override
     public ReservationPaging findAllReservationById(Long memberId, String role, ReservationState state, Long nextCursorId, String period) {
         log.info("Finding reservation by memberId: {}, role: {}, state: {}, nextCursorId: {}, LIMIT:{},  PERIOD: {}",
@@ -98,10 +97,10 @@ public class ReservationServiceImpl implements ReservationService {
     @Transactional
     public ReservationCancelResponse updateReservationState(Long reservationId, Long memberId) {
 
-        /** 락 만듬 */
+        /** 락 만듦 */
         ReentrantLock lock = reservationLocks.get(reservationId, key -> new ReentrantLock());
         try {
-            /** 릭 검 */
+            /** 락 걸기 */
             lock.lock();
 
             /** 맴버 존재 유무 파악 */
@@ -181,7 +180,7 @@ public class ReservationServiceImpl implements ReservationService {
     }
 
     @Override
-    public ReservationFormResponse getReservationForm(Long lockerId){
+    public ReservationFormResponse getReservationForm(Long lockerId) {
         ReservationFormResponse response = lockerMapper.getLockerInfoById(lockerId);
         List<LockerJimTypeResult> jimTypes = lockerMapper.getLockerJimTypeById(lockerId);
         response.setLockerJimTypes(jimTypes);
@@ -191,7 +190,7 @@ public class ReservationServiceImpl implements ReservationService {
     // 예약 등록
     @Override
     @Transactional // 짐타입 등록 실패한 경우 예약 등록까지 롤백
-    public BaseResponseStatus insertReservation(final ReservationInsertRequest request) {
+    public BaseResponseStatus insertReservation(ReservationInsertRequest request) {
         log.info("insertReservation({})", request);
 
         validateStartTimeAndEndTime(request.getStartTime(), request.getEndTime());

--- a/src/main/java/com/airbng/service/ReservationServiceImpl.java
+++ b/src/main/java/com/airbng/service/ReservationServiceImpl.java
@@ -187,11 +187,13 @@ public class ReservationServiceImpl implements ReservationService {
         log.info("insertReservation({})", request);
 
         validateStartTimeAndEndTime(request.getStartTime(), request.getEndTime());
-        validateMember(request.getDropperId(), request.getKeeperId());
         validateLockerKeeper(request.getLockerId(), request.getKeeperId());
         validateJimTypes(request.getLockerId(), request.getJimTypeCounts());
 
+        Long keeperId = lockerMapper.getLockerKepperId(request.getLockerId());
+        request.setKeeperId(keeperId);
         reservationMapper.insertReservation(request);
+
         int cnt = jimTypeMapper.insertReservationJimTypes(request.getId(), request.getJimTypeCounts());
 
         if (cnt != request.getJimTypeCounts().size()) {

--- a/src/main/java/com/airbng/service/ReservationServiceImpl.java
+++ b/src/main/java/com/airbng/service/ReservationServiceImpl.java
@@ -9,6 +9,7 @@ import com.airbng.domain.Reservation;
 import com.airbng.domain.base.ChargeType;
 import com.airbng.domain.base.ReservationState;
 import com.airbng.dto.jimType.JimTypeCountResult;
+import com.airbng.dto.jimType.LockerJimTypeResult;
 import com.airbng.dto.reservation.*;
 import com.airbng.mappers.JimTypeMapper;
 import com.airbng.mappers.LockerMapper;
@@ -177,6 +178,14 @@ public class ReservationServiceImpl implements ReservationService {
             throw new ReservationException(NOT_DROPPER_OF_RESERVATION); // 있는 보관소가 내거 맞나요
 
         return ReservationDetailResponse.from(reservation);
+    }
+
+    @Override
+    public ReservationFormResponse getReservationForm(Long lockerId){
+        ReservationFormResponse response = lockerMapper.getLockerInfoById(lockerId);
+        List<LockerJimTypeResult> jimTypes = lockerMapper.getLockerJimTypeById(lockerId);
+        response.setLockerJimTypes(jimTypes);
+        return response;
     }
 
     // 예약 등록

--- a/src/main/java/com/airbng/service/ReservationServiceImpl.java
+++ b/src/main/java/com/airbng/service/ReservationServiceImpl.java
@@ -182,6 +182,8 @@ public class ReservationServiceImpl implements ReservationService {
     @Override
     public ReservationFormResponse getReservationForm(Long lockerId) {
         ReservationFormResponse response = lockerMapper.getLockerInfoById(lockerId);
+        if(response == null) throw new LockerException(NOT_FOUND_LOCKER);
+
         List<LockerJimTypeResult> jimTypes = lockerMapper.getLockerJimTypeById(lockerId);
         response.setLockerJimTypes(jimTypes);
         return response;

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,0 +1,3 @@
+redis.host=localhost
+redis.port=6379
+redis.password=

--- a/src/main/resources/mappers/LockerMapper.xml
+++ b/src/main/resources/mappers/LockerMapper.xml
@@ -279,5 +279,21 @@
         WHERE locker_id = #{lockerId};
     </select>
 
+
+    <resultMap id="LockerJimTypeResult" type="com.airbng.dto.jimType.LockerJimTypeResult">
+        <result property="jimTypeId" column="jimtype_id"/>
+        <result property="typeName" column="type_name"/>
+        <result property="pricePerHour" column="price_per_hour"/>
+    </resultMap>
+
+    <select id="getLockerJimTypeById" parameterType="Long" resultMap="LockerJimTypeResult">
+        SELECT ljt.jimtype_id AS jimtype_id,
+               jt.type_name AS type_name,
+               jt.price_per_hour AS price_per_hour
+        FROM LockerJimType ljt
+                 JOIN JimType jt ON ljt.jimtype_id = jt.jimtype_id
+        WHERE ljt.locker_id = #{lockerId}
+    </select>
+
 </mapper>
 

--- a/src/main/resources/mappers/LockerMapper.xml
+++ b/src/main/resources/mappers/LockerMapper.xml
@@ -279,6 +279,22 @@
         WHERE locker_id = #{lockerId};
     </select>
 
+    <resultMap id="ReservationFormResponse" type="com.airbng.dto.reservation.ReservationFormResponse">
+        <result property="lockerId" column="locker_id"/>
+        <result property="lockerName" column="locker_name"/>
+        <result property="addressKr" column="address_kr"/>
+    </resultMap>
+
+    <select id="getLockerInfoById" parameterType="Long" resultMap="ReservationFormResponse">
+        SELECT
+            l.locker_id AS locker_id,
+            l.locker_name AS locker_name,
+            l.member_id AS kepper_id,
+            CONCAT(l.address, ' ', l.address_detail) AS address_kr
+        FROM Locker l
+            JOIN Member m ON l.member_id = m.member_id
+        WHERE l.locker_id = #{lockerId}
+    </select>
 
     <resultMap id="LockerJimTypeResult" type="com.airbng.dto.jimType.LockerJimTypeResult">
         <result property="jimTypeId" column="jimtype_id"/>

--- a/src/main/resources/mappers/ReservationMapper.xml
+++ b/src/main/resources/mappers/ReservationMapper.xml
@@ -247,4 +247,10 @@
         WHERE r.reservation_id = #{reservationId}
     </select>
 
+    <select id="getLockerKepperId" parameterType="Long">
+        SELECT member_id
+        FROM locker
+        WHERE locker_id = #{lockerId}
+    </select>
+
 </mapper>

--- a/src/test/java/com/airbng/service/ReservationServiceTest.java
+++ b/src/test/java/com/airbng/service/ReservationServiceTest.java
@@ -65,6 +65,8 @@ class ReservationServiceTest {
 
     @BeforeEach
     public void setUp() {
+        MockHttpSession session = new MockHttpSession();
+
         보관왕 = Member.builder()
                 .memberId(1L)
                 .email("keeper1@airbng.com")
@@ -87,6 +89,7 @@ class ReservationServiceTest {
                 .profileImage(new Image(2L, "profile2.jpg", "https://s3.amazonaws.com/airbng/profile.jpg"))
                 .build();
 
+        session.setAttribute("memberId", 맡김왕.getMemberId());
 
         서울역_보관소 = Locker.builder()
                 .lockerId(1L)
@@ -159,10 +162,8 @@ class ReservationServiceTest {
             // given
             ReservationInsertRequest request = Mockito.spy(perfectRequest);
 
-
             // when
             when(memberMapper.isExistMember(보관왕.getMemberId())).thenReturn(true);
-            when(memberMapper.isExistMember(맡김왕.getMemberId())).thenReturn(true);
             when(lockerMapper.isExistLocker(서울역_보관소.getLockerId())).thenReturn(true);
             when(lockerMapper.isLockerKeeper(서울역_보관소.getLockerId(), 보관왕.getMemberId())).thenReturn(true);
             when(jimTypeMapper.validateLockerJimTypes(서울역_보관소.getLockerId(), List.of(백팩.getJimTypeId(), 캐리어.getJimTypeId()), 2)).thenReturn(true);
@@ -192,7 +193,6 @@ class ReservationServiceTest {
 
                 // when
                 when(memberMapper.isExistMember(보관왕.getMemberId())).thenReturn(true);
-                when(memberMapper.isExistMember(맡김왕.getMemberId())).thenReturn(true);
 
                 when(lockerMapper.isExistLocker(request.getLockerId())).thenReturn(false);
                 LockerException exception = assertThrows(LockerException.class, () -> {
@@ -246,7 +246,6 @@ class ReservationServiceTest {
                     request.setKeeperId(999L); // 존재하지 않는 회원 ID로 변경
 
                     // when
-                    when(memberMapper.isExistMember(맡김왕.getMemberId())).thenReturn(true);
                     when(memberMapper.isExistMember(999L)).thenReturn(false);
 
                     MemberException exception = assertThrows(MemberException.class, () -> {
@@ -282,9 +281,9 @@ class ReservationServiceTest {
                 @BeforeEach
                 void setUp() {
                     when(memberMapper.isExistMember(보관왕.getMemberId())).thenReturn(true);
-                    when(memberMapper.isExistMember(맡김왕.getMemberId())).thenReturn(true);
                     when(lockerMapper.isExistLocker(서울역_보관소.getLockerId())).thenReturn(true);
                     when(lockerMapper.isLockerKeeper(서울역_보관소.getLockerId(), 보관왕.getMemberId())).thenReturn(true);
+//                    when(memberMapper.isExistMember(맡김왕.getMemberId())).thenReturn(true);
                 }
 
                 @Test


### PR DESCRIPTION
## 요약 (Summary)
1. 예약 등록 부분 리팩토링
2. GET 예약 폼 구현
3. 예약 폼 받아오는 테스트 코드 작성

## 🔑 변경 사항 (Key Changes)
1.  예약 등록 시 request 때 keeperId와 dropperId를 받지 않도록 수정하였습니다.
    - dropperId는 로그인한 유저의 경우 session에서 받아오도록 처리 하였습니다.
    - keeperId는 lockerId에서 추출하도록 수정하였습니다.
    - 이에 따라 Test 코드도 일부수정하였습니다.
2. 예약 폼을 받아오는 기능을 구현하였습니다.
   - locker Id를 request param으로 넘기면,
   - 보관소 기본 정보(아이디, 이름, 주소), 해당보관소가 관리하는 짐종류들
    을 반환합니다.
3. 해당 부분에 대한 테스트코드 작성하였습니다.

## 📝 리뷰 요구사항 (To Reviewers)
- [x] 현재 쿼리를 한 번의 조인으로 모두 가져오게 하지 않고, 여러번의 쿼리를 보내 필요한 정보만 가져오도록 작성하였습니다. 뭐가 나을까요!? 
<table>
	<tr>
                <th></th>
		<th>장점</th>
		<th>단점</th>
	</tr>
	<tr>
		<th>한 번의 조인으로 모두 가져오는 경우</th>
		<td>
			- 네트워크 비용이 적음 (DB와의 통신이 한 번이면 됨)<br>
			- 트랜잭션 일관성 유지 쉬움<br>
			- 한 번에 DTO 매핑 가능
		</td>
                 <td>
                        - 3개의 테이블을 조인해야 함 → 성능 하락<br>
			- 1:N 관계에서 중복 많음<br>
			  - 예를 들어 이미지 3개 짐타입 2개면 6개의 행이 중복됨.<br>
		        - 불필요한 column까지 같이 끌려올 수 있음
		</td>
	</tr>
        <tr>
		<th>여러번의 쿼리를 보내 필요한 정보만 가져와 조립하는 경우</th>
		<td>
			- 필요한 정보만 선별 조회 (성능 최적화)<br>
			- 유지보수 용이<br>
			- 중복 없음 (깨끗하게 필요한 정보에 대한 리스트만 뽑을 수 있음)
		</td>
                 <td>
			- 쿼리 수만큼 DB와 통신하므로 네트워크 비용이 커짐<br>
			- 트랜잭션 정합성 (2차 때 개선할 부분이긴 함)
		</td>
	</tr>
</table>

## 확인 방법 
http://localhost:8080/AirBnG/swagger-ui.html 의 `reservation-controller`에서 
`requestParam`만 조절하며 테스트해주세요.
- 요청
   ![image](https://github.com/user-attachments/assets/36cfc9e5-ca44-456b-a818-ec45d6397a13)


<table>
	<tr>
		<th>request param</th>
		<th>예시 사진</th>
	</tr>
	<tr>
		<td>`lockerId = 1` : 정상 요청 </td>
		<td>
			<image src="https://github.com/user-attachments/assets/e0191c1b-24af-465a-9bcb-d85fc5f049c7"/>
		</td>
	</tr>
        <tr>
		<td>`lockerId = 0` : 유효성 검증</td>
		<td>
			<image src="https://github.com/user-attachments/assets/9f2bd4da-1563-4885-8c79-5a14f4963db7"/>
		</td>
	</tr>
        <tr>
		<td>`lockerId = 3` : 없는 보관소인 경우</td>
		<td>
			<image src="https://github.com/user-attachments/assets/13a6d149-8cf6-4818-b5a5-2e5d555e34d6"/>
		</td>
	</tr>
        <tr>
		<td>비활성화된 보관소인 경우 - `PATCH locker/{id}`로 available 조절하고 테스트하시면 됩니다</td>
		<td>
			<image src="https://github.com/user-attachments/assets/85d47a29-cdf9-4cb7-8436-75b2750d70b6"/>
		</td>
	</tr>


</table>

