### PR TITLE
[#81] 보관소 상세 화면 만들기 수정

### DIFF
--- a/src/main/java/com/airbng/controller/LockerController.java
+++ b/src/main/java/com/airbng/controller/LockerController.java
@@ -32,7 +32,7 @@ public class LockerController {
 
 
     @GetMapping("/{lockerId}")
-    public BaseResponse<LockerDetailResponse> findUserById(@PathVariable Long lockerId) {
+    public BaseResponse<LockerDetailResponse> findLockerById(@PathVariable Long lockerId) {
 
         return new BaseResponse<>(lockerService.findUserById(lockerId));
     }

--- a/src/main/java/com/airbng/controller/LockerPageController.java
+++ b/src/main/java/com/airbng/controller/LockerPageController.java
@@ -48,21 +48,8 @@ public class LockerPageController {
                               @RequestParam String reservationDate,
                               Model model) {
 
-        LockerSearchRequest request = LockerSearchRequest.builder()
-                .address(address)
-                .build();
-
-        // 서비스 호출
-        LockerSearchResponse response = lockerService.findAllLockerBySearch(request);
-
-        System.out.println("Address: " + address);
-        System.out.println("Reservation Date: " + reservationDate);
-
-        // JSP에 전달
         model.addAttribute("address", address);
         model.addAttribute("reservationDate", reservationDate);
-        model.addAttribute("lockers", response.getLockers());
-        model.addAttribute("count", response.getCount());
 
         return "search";
     }

--- a/src/main/java/com/airbng/dto/locker/LockerDetailResponse.java
+++ b/src/main/java/com/airbng/dto/locker/LockerDetailResponse.java
@@ -1,5 +1,6 @@
 package com.airbng.dto.locker;
 
+import com.airbng.domain.base.Available;
 import com.airbng.dto.jimType.JimTypeResult;
 import com.airbng.dto.jimType.LockerJimTypeResult;
 import lombok.*;
@@ -17,6 +18,7 @@ public class LockerDetailResponse {
     private String address;
     private String addressEnglish;
     private String addressDetail;
+    private Available isAvailable;
     private Long keeperId;
     private String keeperName;
     private String keeperPhone;

--- a/src/main/java/com/airbng/dto/locker/LockerDetailResponse.java
+++ b/src/main/java/com/airbng/dto/locker/LockerDetailResponse.java
@@ -1,6 +1,7 @@
 package com.airbng.dto.locker;
 
 import com.airbng.dto.jimType.JimTypeResult;
+import com.airbng.dto.jimType.LockerJimTypeResult;
 import lombok.*;
 
 import java.util.List;
@@ -19,7 +20,7 @@ public class LockerDetailResponse {
     private Long keeperId;
     private String keeperName;
     private String keeperPhone;
-    private List<JimTypeResult> jimTypeResults; // 짐 타입 목록; // 종류
+    private List<LockerJimTypeResult> jimTypeResults; // 짐 타입 목록; // 종류
     private List<String> images; // 이미지 리스트
 
 }

--- a/src/main/java/com/airbng/mappers/LockerMapper.java
+++ b/src/main/java/com/airbng/mappers/LockerMapper.java
@@ -26,7 +26,7 @@ public interface LockerMapper {
 
     Long findLockerCount(LockerSearchRequest condition);
 
-    LockerDetailResponse findUserById(Long lockerId);
+    LockerDetailResponse findLockerById(Long lockerId);
 
     List<String> findImageById(Long lockerId);
 

--- a/src/main/java/com/airbng/service/LockerServiceImpl.java
+++ b/src/main/java/com/airbng/service/LockerServiceImpl.java
@@ -47,7 +47,7 @@ public class LockerServiceImpl implements LockerService {
 
     @Override
     public LockerDetailResponse findUserById(Long lockerId) {
-        LockerDetailResponse result = lockerMapper.findUserById(lockerId);
+        LockerDetailResponse result = lockerMapper.findLockerById(lockerId);
         // 만약 result가 null이라면, 해당 lockerId에 대한 정보가 없다는 예외를 발생시킴
         if (result == null) {
             throw new LockerException(NOT_FOUND_LOCKERDETAILS);

--- a/src/main/resources/mappers/LockerMapper.xml
+++ b/src/main/resources/mappers/LockerMapper.xml
@@ -15,14 +15,15 @@
         <result property="keeperName" column="name" />
         <result property="keeperPhone" column="phone" />
         <!-- 중첩 짐타입 매핑 -->
-        <collection property="jimTypeResults" ofType="com.airbng.dto.jimType.JimTypeResult">
+        <collection property="jimTypeResults" ofType="com.airbng.dto.jimType.LockerJimTypeResult">
             <id     column="jimtype_id"    property="jimTypeId" />
             <result column="type_name"     property="typeName" />
+            <result column="price_per_hour"     property="pricePerHour" />
         </collection>
     </resultMap>
 
 
-    <select id="findUserById" parameterType="Long" resultMap="LockerDetails">
+    <select id="findLockerById" parameterType="Long" resultMap="LockerDetails">
         SELECT
             l.locker_id,
             l.locker_name,
@@ -32,8 +33,9 @@
             m.member_id AS keeper_id,
             m.name,
             m.phone,
-            jt.type_name
-
+            jt.jimtype_id,
+            jt.type_name,
+            jt.price_per_hour
         FROM Locker l
             LEFT JOIN Member m ON l.member_id = m.member_id
             LEFT JOIN LockerJimType ljt ON l.locker_id = ljt.locker_id

--- a/src/main/resources/mappers/LockerMapper.xml
+++ b/src/main/resources/mappers/LockerMapper.xml
@@ -14,6 +14,7 @@
         <result property="keeperId" column="keeper_id" />
         <result property="keeperName" column="name" />
         <result property="keeperPhone" column="phone" />
+        <result property="isAvailable" column="is_available" />
         <!-- 중첩 짐타입 매핑 -->
         <collection property="jimTypeResults" ofType="com.airbng.dto.jimType.LockerJimTypeResult">
             <id     column="jimtype_id"    property="jimTypeId" />
@@ -30,6 +31,7 @@
             l.address,
             l.address_english,
             l.address_detail,
+            l.is_available,
             m.member_id AS keeper_id,
             m.name,
             m.phone,

--- a/src/main/webapp/WEB-INF/views/lockerDetails.jsp
+++ b/src/main/webapp/WEB-INF/views/lockerDetails.jsp
@@ -1,9 +1,6 @@
 <%@ page contentType="text/html;charset=UTF-8" language="java" %>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
-<%@ taglib uri="http://java.sun.com/jsp/jstl/functions" prefix="fn" %>
 
-<c:set var="phone" value="${lockerDetail.keeperPhone}" />
-<c:set var="formattedPhone" value="${fn:substring(phone, 0, 3)}-${fn:substring(phone, 3, 7)}-${fn:substring(phone, 7, 11)}" />
 <c:set var="loginMemberId" value="${sessionScope.memberId}" />
 
 <%
@@ -32,71 +29,76 @@
 
     <div class="content">
         <div id="lockerContent">
-            <div class="locker-title">${lockerDetail.lockerName}</div>
-
-            <!-- 이미지 여러 개 출력 -->
-            <c:if test="${not empty lockerDetail.images}">
-                <div class="image-gallery">
-                    <c:forEach var="img" items="${lockerDetail.images}" varStatus="status">
-                        <c:if test="${status.index < 6}">
-                            <img class="locker-image" src="${img}" alt="보관소 이미지 ${status.index + 1}">
-                        </c:if>
-                    </c:forEach>
-                </div>
-            </c:if>
-
-
-            <div class="price-info">
-                 <c:if test="${not empty lockerDetail.jimTypeResults}">
-                    <div class="price-title">
-                        <c:forEach var="type" items="${lockerDetail.jimTypeResults}" varStatus="status">
-                            ${type.typeName}<c:if test="${!status.last}">/</c:if>
-                        </c:forEach>
-                    </div>
-                    <div class="price-detail">
-                        • 시간당 2,000원<br>
-                        • 강남역 도보 3분
-                    </div>
-                </c:if>
+            <!-- 로딩 상태 -->
+            <div class="loading" id="loadingState">
+                보관소 정보를 불러오는 중...
             </div>
 
-            <div class="info-section">
-                <div class="info-item">
-                    <div class="info-label">주소 </div>
-                    <div class="info-value"> | ${lockerDetail.address} ${lockerDetail.addressDetail}</div>
-                </div>
-
-                <div class="info-item">
-                    <div class="info-label">Address</div>
-                    <div class="info-value"> | ${lockerDetail.addressEnglish}</div>
-                </div>
-
-                <div class="info-item">
-                    <div class="info-label">맡아주는 사람</div>
-                    <div class="info-value"> | ${lockerDetail.keeperName}</div>
-                </div>
-
-                <div class="info-item">
-                    <div class="info-label">전화번호</div>
-                    <div class="info-value"> | ${formattedPhone}</div>
-                </div>
+            <!-- 에러 상태 -->
+            <div class="error" id="errorState" style="display: none;">
+                보관소 정보를 불러오는데 실패했습니다.
             </div>
 
+            <!-- 실제 컨텐츠 (JS에서 동적으로 채움) -->
+            <div id="lockerDetailContent" style="display: none;">
+                <div class="locker-title" id="lockerTitle"></div>
+
+                <!-- 이미지 갤러리 -->
+                <div class="image-gallery" id="imageGallery" style="display: none;">
+                </div>
+
+                <!-- 가격 정보 -->
+                <div class="price-info" id="priceInfo">
+                    <div class="price-title" id="priceTitle"></div>
+                    <div class="price-detail" id="priceDetail"></div>
+                </div>
+
+                <!-- 정보 섹션 -->
+                <div class="info-section" id="infoSection">
+                    <div class="info-item">
+                        <div class="info-label">주소 </div>
+                        <div class="info-value" id="address"></div>
+                    </div>
+
+                    <div class="info-item">
+                        <div class="info-label">Address</div>
+                        <div class="info-value" id="addressEnglish"></div>
+                    </div>
+
+                    <div class="info-item">
+                        <div class="info-label">맡아주는 사람</div>
+                        <div class="info-value" id="keeperName"></div>
+                    </div>
+
+                    <div class="info-item">
+                        <div class="info-label">전화번호</div>
+                        <div class="info-value" id="keeperPhone"></div>
+                    </div>
+                </div>
+            </div>
         </div>
     </div>
 
-    <!-- contextPath 반영해서 JS에서 URL 구성 -->
-    <button class="reserve-btn" id="reserveBtn" type="button" data-locker-id="${lockerDetail.lockerId}" data-member-id="${loginMemberId}">
-      보관소 선택
+    <!-- 보관소 선택 버튼 -->
+    <button class="reserve-btn" id="reserveBtn" type="button" style="display: none;"
+            data-context-path="<%=contextPath%>"
+            data-member-id="${loginMemberId}">
+        보관소 선택
     </button>
+</div>
 
-    </div>
+<script>
+    // URL에서 lockerId 추출
+    const urlParams = new URLSearchParams(window.location.search);
+    const lockerId = urlParams.get('lockerId');
+    const memberId = '${loginMemberId}';
+    const contextPath = '<%=contextPath%>';
 
-    <script>
-                const memberId = '${loginMemberId}';
-                console.log('로그인한 회원 ID:', memberId);
-    </script>
+    console.log('Locker ID:', lockerId);
+    console.log('Member ID:', memberId);
+    console.log('Context Path:', contextPath);
+</script>
 
-    <script src="${pageContext.request.contextPath}/js/lockerDetails.js"></script>
+<script src="${pageContext.request.contextPath}/js/lockerDetails.js"></script>
 </body>
 </html>

--- a/src/main/webapp/css/lockerDetails.css
+++ b/src/main/webapp/css/lockerDetails.css
@@ -80,6 +80,7 @@ body {
 .locker-image {
     width: 80px;
     height: 80px;
+    margin:3px;
     border-radius: 8px;
     object-fit: cover;
 }

--- a/src/main/webapp/css/lockerDetails.css
+++ b/src/main/webapp/css/lockerDetails.css
@@ -19,7 +19,7 @@ body {
 }
 
 .header {
-    padding: 80px 160px 16px 160px; /* 상단 80px, 좌우 160px */
+    padding: 30px 160px 16px 160px; /* 상단 80px, 좌우 160px */
     background-color: white;
     display: flex;
     align-items: center;
@@ -27,15 +27,13 @@ body {
     justify-content: center; /* 텍스트 가운데 정렬 */
     position: relative;
     height: 56px;
-
-        display: block; /* 인라인 문제 해결 */
+    display: block; /* 인라인 문제 해결 */
 }
-
 
 .back-btn {
     position: absolute;
     left: 16px;
-    top: 89px; /* 50%에서 60%로 변경하여 화살표를 아래로 이동 */
+    top: 38px; /* 50%에서 60%로 변경하여 화살표를 아래로 이동 */
     transform: translateY(-50%);
     width: 24px;
     height: 24px;
@@ -52,8 +50,7 @@ body {
     font-style: normal;
     font-weight: 600;
     line-height: 20px; /* 100% */
-
-    line-height: 1
+    line-height: 1;
     white-space: nowrap;
 }
 
@@ -61,7 +58,7 @@ body {
     display: flex;
     flex-direction: column;
     align-items: flex-start;
-    padding: 50px 20px;
+    padding: 50px 24px 20px 24px; /* 좌우 패딩 동일하게 */
     background: #FFF;
 }
 
@@ -72,18 +69,26 @@ body {
     color: #333;
 }
 
+.image-gallery {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+    margin-bottom: 16px;
+    width: 100%;
+}
+
 .locker-image {
     width: 80px;
     height: 80px;
     border-radius: 8px;
     object-fit: cover;
-    margin-bottom: 16px;
 }
 
 .price-info {
     padding: 16px;
     border-radius: 8px;
     margin-bottom: 20px;
+    width: 100%;
 }
 
 .price-title {
@@ -93,6 +98,7 @@ body {
     font-style: normal;
     font-weight: 500;
     line-height: 20px; /* 100% */
+    margin-bottom: 8px;
 }
 
 .price-detail {
@@ -107,13 +113,17 @@ body {
 
 .info-section {
     display: flex;
+    min-height: 188px;
     height: 188px;
+    width: 372px;
     padding: 21px 18px;
     flex-direction: column;
     justify-content: center;
     gap: 10px;
-    align-self: stretch;
     background: rgba(69, 97, 219, 0.10);
+    overflow: hidden;
+    margin: 0 auto; /* 가운데 정렬 */
+    box-sizing: border-box; /* 추가: 패딩을 포함한 크기 계산 */
 }
 
 .info-item {
@@ -130,7 +140,6 @@ body {
     font-style: normal;
     font-weight: 600;
     line-height: 17px; /* 100% */
-
     margin-right: 10px; /* 옆으로 간격 줌 */
     min-width: 0px; /* 라벨 길이 정렬 용도 (원하면 조절 가능) */
     white-space: nowrap; /* 줄바꿈 방지 */
@@ -143,16 +152,15 @@ body {
     font-style: normal;
     font-weight: 400;
     line-height: 17px;
-
     text-indent: -10px; /* 라벨 폭 + 간격만큼 음수 들여쓰기 */
     padding-left: 10px; /* 들여쓰기 */
     word-break: break-word;
-     flex: 1; /* 남은 공간 모두 차지 */
+    flex: 1; /* 남은 공간 모두 차지 */
 }
 
 .reserve-btn {
     position: fixed;
-    bottom: 70px;
+    bottom: 30px;
     left: 50%;
     transform: translateX(-50%);
     display: flex;
@@ -168,10 +176,21 @@ body {
     font-size: 16px;
     font-weight: 600;
     cursor: pointer;
+    transition: background-color 0.3s ease;
 }
 
 .reserve-btn:hover {
     background-color: #3367d6;
+}
+
+.reserve-btn.disabled {
+    background-color: #cccccc;
+    color: #666666;
+    cursor: not-allowed;
+}
+
+.reserve-btn.disabled:hover {
+    background-color: #cccccc;
 }
 
 .loading {
@@ -185,9 +204,10 @@ body {
     text-align: center;
     padding: 40px;
     color: #ff5722;
+    font-size: 16px;
 }
 
-/*이미지 css*/
+/* 캐러셀 관련 CSS (미래 사용을 위해 보존) */
 .carousel-container {
     position: relative;
     overflow: hidden;

--- a/src/main/webapp/js/lockerDetails.js
+++ b/src/main/webapp/js/lockerDetails.js
@@ -1,32 +1,245 @@
 window.addEventListener("DOMContentLoaded", function () {
-    // 🔹 슬라이드 관련 로직
-    let currentSlide = 0;
-    const track = document.getElementById('carouselTrack');
-    const totalSlides = track?.children.length || 0;
+    // URL에서 lockerId 추출
+    const urlParams = new URLSearchParams(window.location.search);
+    const lockerId = urlParams.get('lockerId');
 
-    window.moveSlide = function (direction) {
-        if (!track || totalSlides === 0) return;
+    if (!lockerId) {
+        showError('보관소 ID가 제공되지 않았습니다.');
+        return;
+    }
 
-        currentSlide += direction;
+    // 보관소 데이터 로드
+    loadLockerDetails(lockerId);
 
-        if (currentSlide < 0) {
-            currentSlide = 0;
-        } else if (currentSlide >= totalSlides) {
-            currentSlide = totalSlides - 1;
-        }
-
-        track.style.transform = `translateX(-${currentSlide * 100}%)`;
-    };
-
-    // 🔹 보관소 선택 버튼 클릭 시 이동
+    // 🔹 보관소 선택 버튼 클릭 이벤트
     const reserveBtn = document.getElementById("reserveBtn");
     reserveBtn?.addEventListener("click", function () {
+        // 버튼이 비활성화 상태면 동작하지 않음
+        if (reserveBtn.disabled) {
+            return;
+        }
+
         const contextPath = reserveBtn.dataset.contextPath || '';
         const lockerId = reserveBtn.dataset.lockerId;
         const memberId = reserveBtn.dataset.memberId;
+
+        if (!lockerId || !memberId) {
+            alert('로그인이 필요합니다.');
+            return;
+        }
 
         const targetUrl = `${contextPath}/page/reservation?lockerId=${encodeURIComponent(lockerId)}&memberId=${encodeURIComponent(memberId)}`;
         console.log("이동할 URL:", targetUrl);
         window.location.href = targetUrl;
     });
 });
+
+/**
+ * 보관소 상세 정보를 API에서 가져오는 함수
+ */
+async function loadLockerDetails(lockerId) {
+    try {
+        showLoading(true);
+
+        const response = await fetch(`${contextPath}/lockers/${lockerId}`);
+
+        if (!response.ok) {
+            throw new Error(`HTTP error! status: ${response.status}`);
+        }
+
+        const data = await response.json();
+
+        if (data.code === 1000 && data.result) {
+            renderLockerDetails(data.result);
+        } else {
+            throw new Error(data.message || '보관소 정보를 불러오는데 실패했습니다.');
+        }
+
+    } catch (error) {
+        console.error('API 호출 에러:', error);
+        showError('보관소 정보를 불러오는데 실패했습니다.');
+    } finally {
+        showLoading(false);
+    }
+}
+
+/**
+ * 보관소 상세 정보를 화면에 렌더링
+ */
+function renderLockerDetails(lockerDetail) {
+    // 보관소 이름
+    document.getElementById('lockerTitle').textContent = lockerDetail.lockerName;
+
+    // 이미지 갤러리 렌더링
+    renderImageGallery(lockerDetail.images);
+
+    // 가격 정보 렌더링
+    renderPriceInfo(lockerDetail.jimTypeResults);
+
+    // 보관소 정보 렌더링
+    renderLockerInfo(lockerDetail);
+
+    // 보관소 선택 버튼 설정
+    setupReserveButton(lockerDetail.lockerId, lockerDetail.isAvailable);
+
+    // 컨텐츠 표시
+    document.getElementById('lockerDetailContent').style.display = 'block';
+    document.getElementById('reserveBtn').style.display = 'flex';
+}
+
+/**
+ * 이미지 갤러리 렌더링
+ */
+function renderImageGallery(images) {
+    const imageGallery = document.getElementById('imageGallery');
+
+    if (!images || images.length === 0) {
+        imageGallery.style.display = 'none';
+        return;
+    }
+
+    imageGallery.innerHTML = '';
+
+    // 최대 6개 이미지만 표시
+    const maxImages = Math.min(images.length, 6);
+
+    for (let i = 0; i < maxImages; i++) {
+        const img = document.createElement('img');
+        img.className = 'locker-image';
+        img.src = images[i];
+        img.alt = `보관소 이미지 ${i + 1}`;
+        img.onerror = function() {
+            this.style.display = 'none'; // 이미지 로드 실패 시 숨김
+        };
+        imageGallery.appendChild(img);
+    }
+
+    imageGallery.style.display = 'block';
+}
+
+/**
+ * 가격 정보 렌더링
+ */
+function renderPriceInfo(jimTypeResults) {
+    const priceTitle = document.getElementById('priceTitle');
+    const priceDetail = document.getElementById('priceDetail');
+
+    if (!jimTypeResults || jimTypeResults.length === 0) {
+        priceTitle.textContent = '가격 정보 없음';
+        priceDetail.innerHTML = '• 가격 정보를 확인할 수 없습니다.';
+        return;
+    }
+
+    // 짐 타입 이름들을 "/"로 구분하여 표시
+    const typeNames = jimTypeResults.map(type => type.typeName).join('/');
+    priceTitle.textContent = typeNames;
+
+    // 가격 정보 생성
+    let priceDetailHtml = '';
+
+    // 각 짐 타입별 가격 정보
+    jimTypeResults.forEach(type => {
+        priceDetailHtml += `• ${type.typeName}: 시간당 ${type.pricePerHour.toLocaleString()}원<br>`;
+    });
+
+    // 고정 정보 추가 (필요시 수정)
+    priceDetailHtml += '• 강남역 도보 3분';
+
+    priceDetail.innerHTML = priceDetailHtml;
+}
+
+/**
+ * 보관소 정보 렌더링
+ */
+function renderLockerInfo(lockerDetail) {
+    // 주소 정보
+    const fullAddress = `${lockerDetail.address} ${lockerDetail.addressDetail || ''}`.trim();
+    document.getElementById('address').textContent = ` | ${fullAddress}`;
+    document.getElementById('addressEnglish').textContent = ` | ${lockerDetail.addressEnglish}`;
+
+    // 관리자 정보
+    document.getElementById('keeperName').textContent = ` | ${lockerDetail.keeperName}`;
+
+    // 전화번호 포맷팅
+    const formattedPhone = formatPhoneNumber(lockerDetail.keeperPhone);
+    document.getElementById('keeperPhone').textContent = ` | ${formattedPhone}`;
+}
+
+/**
+ * 보관소 선택 버튼 설정
+ */
+function setupReserveButton(lockerId, isAvailable) {
+    const reserveBtn = document.getElementById('reserveBtn');
+    if (reserveBtn) {
+        reserveBtn.dataset.lockerId = lockerId;
+
+        // 이용 가능 여부에 따른 버튼 상태 설정
+        if (isAvailable === 'NO') {
+            reserveBtn.disabled = true;
+            reserveBtn.classList.add('disabled');
+            reserveBtn.textContent = '이용 불가';
+        } else {
+            reserveBtn.disabled = false;
+            reserveBtn.classList.remove('disabled');
+            reserveBtn.textContent = '보관소 선택';
+        }
+    }
+}
+
+/**
+ * 전화번호 포맷팅 함수
+ */
+function formatPhoneNumber(phone) {
+    if (!phone) return '';
+
+    // 숫자만 추출
+    const numbers = phone.replace(/\D/g, '');
+
+    // 11자리 휴대폰 번호인 경우
+    if (numbers.length === 11) {
+        return `${numbers.substring(0, 3)}-${numbers.substring(3, 7)}-${numbers.substring(7, 11)}`;
+    }
+
+    // 10자리 일반 전화번호인 경우
+    if (numbers.length === 10) {
+        return `${numbers.substring(0, 3)}-${numbers.substring(3, 6)}-${numbers.substring(6, 10)}`;
+    }
+
+    // 기타 경우 그대로 반환
+    return phone;
+}
+
+/**
+ * 로딩 상태 표시/숨김
+ */
+function showLoading(show) {
+    const loadingState = document.getElementById('loadingState');
+    const errorState = document.getElementById('errorState');
+    const detailContent = document.getElementById('lockerDetailContent');
+    const reserveBtn = document.getElementById('reserveBtn');
+
+    if (show) {
+        loadingState.style.display = 'block';
+        errorState.style.display = 'none';
+        detailContent.style.display = 'none';
+        reserveBtn.style.display = 'none';
+    } else {
+        loadingState.style.display = 'none';
+    }
+}
+
+/**
+ * 에러 상태 표시
+ */
+function showError(message) {
+    const loadingState = document.getElementById('loadingState');
+    const errorState = document.getElementById('errorState');
+    const detailContent = document.getElementById('lockerDetailContent');
+    const reserveBtn = document.getElementById('reserveBtn');
+
+    loadingState.style.display = 'none';
+    errorState.style.display = 'block';
+    errorState.textContent = message;
+    detailContent.style.display = 'none';
+    reserveBtn.style.display = 'none';
+}

--- a/src/test/java/com/airbng/service/LockerServiceTest.java
+++ b/src/test/java/com/airbng/service/LockerServiceTest.java
@@ -218,7 +218,7 @@ class LockerServiceTest {
 
         List<String> mockImages = List.of("img1.jpg", "img2.jpg");
 
-        Mockito.when(lockerMapper.findUserById(lockerId)).thenReturn(mockResponse);
+        Mockito.when(lockerMapper.findLockerById(lockerId)).thenReturn(mockResponse);
         Mockito.when(lockerMapper.findImageById(lockerId)).thenReturn(mockImages);
 
         // when
@@ -237,7 +237,7 @@ class LockerServiceTest {
     void findUserById_결과없음_예외발생() {
         // given
         Long lockerId = 999L;
-        Mockito.when(lockerMapper.findUserById(lockerId)).thenReturn(null);
+        Mockito.when(lockerMapper.findLockerById(lockerId)).thenReturn(null);
 
         // when
         LockerException exception = assertThrows(LockerException.class, () -> {


### PR DESCRIPTION
## 요약 (Summary)
- [x] 보관소 상세 화면 만들기 수정
- [x] 아 그니까 보관소 상세에서 짐타입 가격정보를 동적으로 받아오게 하였습니다.
- [x] 서버사이드 렌더링 아이고 API 를 통해 받아오도록 하였습니다!  
- [x] API 스펙을 수정 하였습니다. 

## 🔑 변경 사항 (Key Changes)

- 락커 컨트롤러 수정
- 락커 디테일 jsp, js, css 수정
- API 스펙을 수정 : 짐의 가격, 보관소의 이용가능 유무 응답에 포함

## 📝 리뷰 요구사항 (To Reviewers)

- [ ] 보관소 상세 화면이 실제 정보를 적절하게 잘 보여주는 확인해주세요!

## 확인 방법 

#### 이용 가능, 짐타입 다수. 
![스크린샷 2025-07-04 오후 12 48 20](https://github.com/user-attachments/assets/d6917844-2ae5-444a-abf6-057cf4759283)



#### 이용 불가  
![스크린샷 2025-07-04 오후 12 28 11](https://github.com/user-attachments/assets/0e1da66a-c076-43a4-998e-0431733ac825)

