### PR TITLE
[#111] 그라파나 + 프로메테우스 적용

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,10 +39,12 @@ src/main/webapp/js/config/
 
 ### gradle 관련 ###
 .gradle/
+.gradle/*
 .gradle
 .lock
 .lock/
 .bin/
+.bin/*
 .bin
 
 # Avoid ignoring Gradle wrapper jar file, Gradle wrappper properties

--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,7 @@ gradle-app.setting
 
 # Cache of project
 .gradletasknamecache
+
+**/*.lock
+**/*.bin.gradle/**/*.lock
+.gradle/**/*.bin

--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,10 @@ src/main/webapp/js/config/
 ### gradle 관련 ###
 .gradle/
 .gradle
+.lock
+.lock/
+.bin/
+.bin
 
 # Avoid ignoring Gradle wrapper jar file, Gradle wrappper properties
 !gradle-wrapper.jar

--- a/build.gradle
+++ b/build.gradle
@@ -68,6 +68,9 @@ dependencies {
     // Test
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.mybatis.spring.boot:mybatis-spring-boot-starter-test:3.0.4'
+
+    implementation 'org.springframework.boot:spring-boot-starter-actuator'
+    runtimeOnly 'io.micrometer:micrometer-registry-prometheus'
 }
 
 tasks.named('test') {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,25 @@
+version: '3.8'
+services:
+  prometheus:
+    image: prom/prometheus:latest
+    container_name: prometheus
+    volumes:
+      - ./prometheus.yml:/etc/prometheus/prometheus.yml
+    command:
+      - '--config.file=/etc/prometheus/prometheus.yml'
+    ports:
+      - "9090:9090"
+    networks:
+      - monitoring-network
+
+  grafana:
+    image: grafana/grafana:latest
+    container_name: grafana
+    ports:
+      - "3000:3000"
+    networks:
+      - monitoring-network
+
+networks:
+  monitoring-network:
+    driver: bridge

--- a/prometheus.yml
+++ b/prometheus.yml
@@ -1,0 +1,8 @@
+global:
+  scrape_interval: 15s
+
+scrape_configs:
+  - job_name: prometheus
+    metrics_path: '/actuator/prometheus'
+    static_configs:
+      - targets: ['host.docker.internal:9000']

--- a/prometheus.yml
+++ b/prometheus.yml
@@ -3,6 +3,6 @@ global:
 
 scrape_configs:
   - job_name: prometheus
-    metrics_path: '/actuator/prometheus'
+    metrics_path: '/AirBnG/actuator/prometheus'
     static_configs:
       - targets: ['host.docker.internal:9000']

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -22,7 +22,7 @@ management:
   endpoints:
     web:
       exposure:
-        include: "prometheus"
+        include: "*"
   metrics:
     export:
       prometheus:

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -18,6 +18,17 @@ spring:
         default_batch_fetch_size: 100
     open-in-view: false
 
+management:
+  endpoints:
+    web:
+      exposure:
+        include: "prometheus"
+  metrics:
+    export:
+      prometheus:
+        enabled: true
+
+
 logging.level:
   org.hibernate.SQL: debug
   org.hibernate.type: trace


### PR DESCRIPTION
## 요약 (Summary)
- [x] 그라파나 + 프로메테우스 적용

## 🔑 변경 사항 (Key Changes)

- 애플리케이션 내부 지표 (ex. CPU 사용량, HTTP 요청 수 등)를 외부 시각화 도구와 연동하여 팀 전체 가시성 확보를 위해 (그라파나 + 프로메테우스)를 적용했습니다.
- 일단 로컬에서만 적용했는데 각자 로컬에서 잘 작동하는지 확인해주세요

## 📝 리뷰 요구사항 (To Reviewers)

- [ ] 로컬에서 잘 작동하는지 확인해주세요

## 확인 방법 
 
1. 터미널에서 `docker-compose up -d` 명령어 실행
2. `http://localhost:3000` 으로 접속 (기본 ID/PW: `admin / admin`)
3. Data Sources 등록
      1. 좌측 메뉴 → Data Sources → Add data source
      2. Prometheus 선택
      3. URL: `http://host.docker.internal:9090` 입력
      4. Save & Test
4. 대시보드 Import
    1. Grafana 대시보드 → + → Import
    2. Dashboard ID에 `4701` 입력 (JVM Micrometer용 대시보드)
    3. Prometheus 데이터 소스 선택 후 Import

아래 화면 확인되면 끝
<img width="2048" height="1228" alt="image" src="https://github.com/user-attachments/assets/efaffdfa-648f-49aa-98f5-a72a969531b1" />
