### PR TITLE
[#109] 인기보관소 캐시 성능 개선 및 예약 카운트 반정규화 적용

### DIFF
--- a/src/main/java/com/airbng/config/CacheConfig.java
+++ b/src/main/java/com/airbng/config/CacheConfig.java
@@ -1,5 +1,6 @@
 package com.airbng.config;
 
+import com.airbng.dto.locker.LockerTop5Response;
 import com.github.benmanes.caffeine.cache.Cache;
 import com.github.benmanes.caffeine.cache.Caffeine;
 import com.github.benmanes.caffeine.cache.Scheduler;
@@ -20,6 +21,18 @@ public class CacheConfig {
         return Caffeine.newBuilder()
                 .expireAfterAccess(10, TimeUnit.MINUTES)
                 .scheduler(Scheduler.systemScheduler())
+                .build();
+    }
+
+    /**
+     * 1시간마다 만료
+     * 백그라운드 옵션제거
+     * 트래픽 있을 때만 lazy load하고, 없으면 그대로 놔둬도 됨
+     * */
+    @Bean
+    public Cache<String, LockerTop5Response> lockerTop5Cache() {
+        return Caffeine.newBuilder()
+                .expireAfterAccess(1, TimeUnit.HOURS)
                 .build();
     }
 }

--- a/src/main/java/com/airbng/domain/Locker.java
+++ b/src/main/java/com/airbng/domain/Locker.java
@@ -8,6 +8,7 @@ import com.airbng.domain.jimtype.JimType;
 import com.airbng.domain.jimtype.LockerJimType;
 import jakarta.persistence.*;
 import lombok.*;
+import org.hibernate.annotations.ColumnDefault;
 import org.springframework.lang.NonNull;
 
 import java.util.HashSet;
@@ -65,6 +66,10 @@ public class Locker extends BaseTime {
 
     @OneToMany(mappedBy = "locker")
     private Set<Zzim> zzims;
+
+    @Column(nullable = false)
+    @ColumnDefault("0")
+    private Long reservationCount;
 
     public boolean validateLockerJimtype(JimType jimType){
         return lockerJimTypes.stream()

--- a/src/main/java/com/airbng/repository/LockerRepository.java
+++ b/src/main/java/com/airbng/repository/LockerRepository.java
@@ -27,10 +27,7 @@ public interface LockerRepository extends JpaRepository<Locker, Long> {
             "LEFT JOIN FETCH li.image i " +
             "LEFT JOIN FETCH l.lockerJimTypes lj " +
             "JOIN FETCH lj.jimType j " +
-            "WHERE EXISTS (SELECT r FROM Reservation r " +
-            "WHERE r.keeper = l.keeper AND r.state = :state) "+
-            "ORDER BY (SELECT COUNT(r) FROM Reservation r " +
-            "WHERE r.keeper = l.keeper AND r.state = :state) DESC " +
+            "ORDER BY l.reservationCount DESC " +
             "limit 5")
     List<Locker> findTop5LockersByReservation(ReservationState state);
 }

--- a/src/main/java/com/airbng/service/LockerServiceImpl.java
+++ b/src/main/java/com/airbng/service/LockerServiceImpl.java
@@ -12,14 +12,18 @@ import com.airbng.dto.locker.*;
 import com.airbng.mappers.LockerMapper;
 import com.airbng.repository.LockerRepository;
 import com.airbng.util.S3Utils;
+import com.github.benmanes.caffeine.cache.Cache;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.*;
+import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
@@ -36,6 +40,7 @@ public class LockerServiceImpl implements LockerService {
     private final LockerRepository lockerRepository;
     private final S3Utils s3Utils;
 
+    private final Cache<String, LockerTop5Response> localCache;
 
     @Override
     public LockerSearchResponse findAllLockerBySearch(LockerSearchRequest request) {
@@ -72,10 +77,11 @@ public class LockerServiceImpl implements LockerService {
 
     @Override
     public LockerTop5Response findTop5Locker() {
-        List<Locker> lockers = lockerRepository
-                .findTop5LockersByReservation(ReservationState.COMPLETED);
-
-        return LockerTop5Response.from(lockers);
+        return localCache.get("lockerTop5", key -> {
+            List<Locker> lockers = lockerRepository
+                    .findTop5LockersByReservation(ReservationState.COMPLETED);
+            return LockerTop5Response.from(lockers);
+        });
     }
 
     @Transactional(rollbackFor = Exception.class)

--- a/src/main/java/com/airbng/service/LockerServiceImpl.java
+++ b/src/main/java/com/airbng/service/LockerServiceImpl.java
@@ -15,17 +15,12 @@ import com.airbng.util.S3Utils;
 import com.github.benmanes.caffeine.cache.Cache;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
 import java.util.*;
-import java.util.concurrent.locks.ReentrantLock;
-import java.util.function.Function;
-import java.util.stream.Collectors;
 
 import static com.airbng.common.response.status.BaseResponseStatus.*;
 


### PR DESCRIPTION
## 요약 (Summary)

* 인기 보관소 데이터 조회 최적화를 위해 로컬 캐시(Caffeine) TTL 기반 만료 전략 적용
* 인기 보관소 예약 건수 조회를 위한 `reservationCount` 칼럼 추가 및 반정규화 처리

## 🔑 변경 사항 (Key Changes)

* `Locker` 엔티티에 `reservationCount` 칼럼 추가 (`Long` 타입, 기본값 0)
* Caffeine 캐시를 TTL(1시간) 적용해 DB 부하 감소 및 데이터 정합성 관리
* 캐시 만료 스케줄러 제거, 접근 기반 만료 방식으로 변경

## 📝 리뷰 요구사항 (To Reviewers)

- [ ] 캐시 만료 정책과 반정규화 컬럼 추가에 따른 데이터 정합성 보장 여부 검토
- [ ] 성능 영향 및 코드 클린업 여부 확인
- [ ] 맬론차트 참고 ( 인기보관소 일정 시간 기준으로비즈니스 정책 변경으로 DB 부하 감소)

## 확인 방법

1. 홈 화면 인기 보관소 조회 시 캐시가 정상 동작하는지 확인
2. 신규 예약 생성 후 `reservationCount` 값이 올바르게 증가하는지 DB 확인
3. 캐시 접근 시 TTL 만료 후 데이터 갱신이 정상적으로 되는지 테스트
