### PR TITLE
[#130] BE 보관소 jpa로 변경

### DIFF
--- a/src/main/java/com/airbng/config/SecurityConfig.java
+++ b/src/main/java/com/airbng/config/SecurityConfig.java
@@ -62,7 +62,7 @@ public class SecurityConfig {
                                 "/login", "/members/signup", "/reissue",
                                 "/members/check-email","/members/check-nickname",
                                 "/swagger-ui/**","/swagger-resources/**", "/v3/api-docs/**",
-                                "swagger-ui.html","/webjars/**", "/lockers")
+                                "swagger-ui.html","/webjars/**", "/lockers", "/lockers/popular")
                         .permitAll()
                         .anyRequest().authenticated()
                 )

--- a/src/main/java/com/airbng/config/SecurityConfig.java
+++ b/src/main/java/com/airbng/config/SecurityConfig.java
@@ -62,7 +62,7 @@ public class SecurityConfig {
                                 "/login", "/members/signup", "/reissue",
                                 "/members/check-email","/members/check-nickname",
                                 "/swagger-ui/**","/swagger-resources/**", "/v3/api-docs/**",
-                                "swagger-ui.html","/webjars/**", "/lockers", "/lockers/popular")
+                                "swagger-ui.html","/webjars/**", "/lockers", "/lockers/popular", "/error")
                         .permitAll()
                         .anyRequest().authenticated()
                 )

--- a/src/main/java/com/airbng/config/SecurityConfig.java
+++ b/src/main/java/com/airbng/config/SecurityConfig.java
@@ -62,7 +62,7 @@ public class SecurityConfig {
                                 "/login", "/members/signup", "/reissue",
                                 "/members/check-email","/members/check-nickname",
                                 "/swagger-ui/**","/swagger-resources/**", "/v3/api-docs/**",
-                                "swagger-ui.html","/webjars/**")
+                                "swagger-ui.html","/webjars/**", "/lockers")
                         .permitAll()
                         .anyRequest().authenticated()
                 )

--- a/src/main/java/com/airbng/controller/JimTypeController.java
+++ b/src/main/java/com/airbng/controller/JimTypeController.java
@@ -1,0 +1,25 @@
+package com.airbng.controller;
+
+import com.airbng.common.response.BaseResponse;
+import com.airbng.dto.jimType.JimTypeResponse;
+import com.airbng.service.JimTypeService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/jimtypes")
+public class JimTypeController {
+
+    private final JimTypeService jimTypeService;
+
+    @GetMapping
+    public BaseResponse<List<JimTypeResponse>> getAllJimTypes() {
+        return new BaseResponse<>(jimTypeService.findAllJimTypes());
+    }
+
+}

--- a/src/main/java/com/airbng/controller/LockerController.java
+++ b/src/main/java/com/airbng/controller/LockerController.java
@@ -35,8 +35,7 @@ public class LockerController {
     @GetMapping("/{lockerId}")
     @PreAuthorize("hasAnyAuthority('USER')")
     public BaseResponse<LockerDetailResponse> findLockerById(@PathVariable Long lockerId) {
-        lockerService.findLockerById(lockerId);
-        return new BaseResponse<>(SUCCESS);
+        return new BaseResponse<>(lockerService.findLockerById(lockerId));
     }
 
     @PatchMapping("/{lockerId}")
@@ -68,15 +67,13 @@ public class LockerController {
     @GetMapping("/popular")
     public BaseResponse<LockerTop5Response> selectTop5Lockers() {
         log.info("LockerController.selectTop5Lockers");
-        lockerService.findTop5Locker();
-        return new BaseResponse<>(SUCCESS);
+        return new BaseResponse<>(lockerService.findTop5Locker());
     }
 
     @GetMapping("/update/{lockerId}")
     @PreAuthorize("hasAnyAuthority('USER')")
     public BaseResponse<LockerUpdateResponse> findLockerForUpdate(@PathVariable Long lockerId) {
-        lockerService.findUpdateUserById(lockerId);
-        return new BaseResponse<>(SUCCESS);
+        return new BaseResponse<>(lockerService.findUpdateUserById(lockerId));
     }
 
 
@@ -98,8 +95,7 @@ public class LockerController {
     @PreAuthorize("hasAnyAuthority('USER')")
     public BaseResponse<Boolean> hasMyLocker(@AuthenticationPrincipal CustomUserDetails principal) {
         Long memberId = principal.getId();
-        lockerService.isExistLocker(memberId);
-        return new BaseResponse<>(SUCCESS);
+        return new BaseResponse<>(lockerService.isExistLocker(memberId));
     }
 
     /** 내 보관소 상세(뷰 용) */
@@ -107,8 +103,7 @@ public class LockerController {
     @PreAuthorize("hasAnyAuthority('USER')")
     public BaseResponse<LockerDetailResponse> myLocker(@AuthenticationPrincipal CustomUserDetails principal) {
         Long memberId = principal.getId();
-        lockerService.findMyLocker(memberId);
-        return new BaseResponse<>(SUCCESS);
+        return new BaseResponse<>(lockerService.findMyLocker(memberId));
     }
 
     /** 내 보관소 수정 화면용 데이터 */
@@ -116,8 +111,7 @@ public class LockerController {
     @PreAuthorize("hasAnyAuthority('USER')")
     public BaseResponse<LockerUpdateResponse> myLockerForUpdate(@AuthenticationPrincipal CustomUserDetails principal) {
         Long memberId = principal.getId();
-        lockerService.findUpdateMyLocker(memberId);
-        return new BaseResponse<>(SUCCESS);
+        return new BaseResponse<>(lockerService.findUpdateMyLocker(memberId));
     }
 
 }

--- a/src/main/java/com/airbng/controller/LockerController.java
+++ b/src/main/java/com/airbng/controller/LockerController.java
@@ -3,6 +3,7 @@ package com.airbng.controller;
 import com.airbng.common.response.BaseResponse;
 import com.airbng.common.response.status.BaseResponseStatus;
 import com.airbng.dto.locker.*;
+import com.airbng.security.domain.CustomUserDetails;
 import com.airbng.service.LockerService;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
@@ -11,6 +12,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
@@ -33,8 +35,8 @@ public class LockerController {
     @GetMapping("/{lockerId}")
     @PreAuthorize("hasAnyAuthority('USER')")
     public BaseResponse<LockerDetailResponse> findLockerById(@PathVariable Long lockerId) {
-
-        return new BaseResponse<>(lockerService.findLockerById(lockerId));
+        lockerService.findLockerById(lockerId);
+        return new BaseResponse<>(SUCCESS);
     }
 
     @PatchMapping("/{lockerId}")
@@ -66,13 +68,15 @@ public class LockerController {
     @GetMapping("/popular")
     public BaseResponse<LockerTop5Response> selectTop5Lockers() {
         log.info("LockerController.selectTop5Lockers");
-        return new BaseResponse<>(lockerService.findTop5Locker());
+        lockerService.findTop5Locker();
+        return new BaseResponse<>(SUCCESS);
     }
 
     @GetMapping("/update/{lockerId}")
     @PreAuthorize("hasAnyAuthority('USER')")
     public BaseResponse<LockerUpdateResponse> findLockerForUpdate(@PathVariable Long lockerId) {
-        return new BaseResponse<>(lockerService.findUpdateUserById(lockerId));
+        lockerService.findUpdateUserById(lockerId);
+        return new BaseResponse<>(SUCCESS);
     }
 
 
@@ -87,6 +91,33 @@ public class LockerController {
         request.setImages(images);
         lockerService.updateLocker(request);
         return new BaseResponse<>("보관소 수정 완료");
+    }
+
+    /** 내 보관소 보유 여부 (true/false) */
+    @GetMapping("/me/exist")
+    @PreAuthorize("hasAnyAuthority('USER')")
+    public BaseResponse<Boolean> hasMyLocker(@AuthenticationPrincipal CustomUserDetails principal) {
+        Long memberId = principal.getId();
+        lockerService.isExistLocker(memberId);
+        return new BaseResponse<>(SUCCESS);
+    }
+
+    /** 내 보관소 상세(뷰 용) */
+    @GetMapping("/me")
+    @PreAuthorize("hasAnyAuthority('USER')")
+    public BaseResponse<LockerDetailResponse> myLocker(@AuthenticationPrincipal CustomUserDetails principal) {
+        Long memberId = principal.getId();
+        lockerService.findMyLocker(memberId);
+        return new BaseResponse<>(SUCCESS);
+    }
+
+    /** 내 보관소 수정 화면용 데이터 */
+    @GetMapping("/me/update")
+    @PreAuthorize("hasAnyAuthority('USER')")
+    public BaseResponse<LockerUpdateResponse> myLockerForUpdate(@AuthenticationPrincipal CustomUserDetails principal) {
+        Long memberId = principal.getId();
+        lockerService.findUpdateMyLocker(memberId);
+        return new BaseResponse<>(SUCCESS);
     }
 
 }

--- a/src/main/java/com/airbng/controller/LockerController.java
+++ b/src/main/java/com/airbng/controller/LockerController.java
@@ -47,8 +47,9 @@ public class LockerController {
 
     @DeleteMapping("/{lockerId}")
     @PreAuthorize("hasAnyAuthority('USER')")
-    public BaseResponse<String> deleteLocker(@PathVariable Long lockerId) {
-        lockerService.deleteLocker(lockerId);
+    public BaseResponse<String> deleteLocker(@PathVariable Long lockerId,
+                                             @AuthenticationPrincipal CustomUserDetails userDetails) {
+        lockerService.deleteLocker(lockerId, userDetails);
         return new BaseResponse<>("보관소 삭제 완료");
     }
 

--- a/src/main/java/com/airbng/controller/LockerController.java
+++ b/src/main/java/com/airbng/controller/LockerController.java
@@ -87,11 +87,11 @@ public class LockerController {
     public BaseResponse<String> updateLocker(
             @PathVariable Long lockerId,
             @RequestPart("locker") LockerUpdateRequest request,
-            @RequestPart(value = "images", required = false) List<MultipartFile> images
+            @RequestPart(value = "images", required = false) List<MultipartFile> images,
+            @AuthenticationPrincipal CustomUserDetails principal
     ) throws IOException {
         request.setLockerId(lockerId);
-        request.setImages(images);
-        lockerService.updateLocker(request);
+        lockerService.updateLocker(principal.getId(), request, images);
         return new BaseResponse<>("보관소 수정 완료");
     }
 

--- a/src/main/java/com/airbng/controller/LockerController.java
+++ b/src/main/java/com/airbng/controller/LockerController.java
@@ -64,7 +64,6 @@ public class LockerController {
 
 
     @GetMapping("/popular")
-    @PreAuthorize("hasAnyAuthority('USER')")
     public BaseResponse<LockerTop5Response> selectTop5Lockers() {
         log.info("LockerController.selectTop5Lockers");
         return new BaseResponse<>(lockerService.findTop5Locker());

--- a/src/main/java/com/airbng/controller/LockerSearchController.java
+++ b/src/main/java/com/airbng/controller/LockerSearchController.java
@@ -14,7 +14,7 @@ import java.util.List;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/lockers")
-@PreAuthorize("hasAnyAuthority('USER')")
+//@PreAuthorize("hasAnyAuthority('USER')")
 public class LockerSearchController {
 
     private final LockerService lockerService;

--- a/src/main/java/com/airbng/domain/Member.java
+++ b/src/main/java/com/airbng/domain/Member.java
@@ -60,20 +60,6 @@ public class Member extends BaseTime {
     @OneToMany(mappedBy = "member")
     private Set<Zzim> zzims;
 
-    //   테스트용
-    public static Member withId(Long memberId) {
-        return Member.builder()
-                .memberId(memberId)
-                .email("owner@airbng.com")
-                .name("홍길동")
-                .phone("010-1234-5678")
-                .nickname("lockerKing")
-                .password("encoded_password")
-                .status(BaseStatus.ACTIVE)
-                .profileImage(Image.withId(101L))
-                .build();
-    }
-
     public Member(Long memberId, String role) {
         this.memberId = memberId;
         this.role = Role.valueOf(role);

--- a/src/main/java/com/airbng/domain/image/Image.java
+++ b/src/main/java/com/airbng/domain/image/Image.java
@@ -32,13 +32,4 @@ public class Image extends BaseTime {
     @Column(nullable = false, columnDefinition = "VARCHAR(10)")
     private BaseStatus status;
 
-    // com.airbng.domain.image.Image
-    public static Image withId(Long imageId) {
-        return Image.builder()
-                .imageId(imageId)
-                .url("https://example.com/images/profile" + imageId + ".jpg")
-                .uploadName("profile" + imageId + ".jpg")
-                .build();
-    }
-
 }

--- a/src/main/java/com/airbng/dto/jimType/JimTypeResponse.java
+++ b/src/main/java/com/airbng/dto/jimType/JimTypeResponse.java
@@ -1,0 +1,27 @@
+package com.airbng.dto.jimType;
+
+import com.airbng.domain.jimtype.JimType;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+@AllArgsConstructor
+public class JimTypeResponse {
+
+    private Long jimTypeId;
+    private String typeName;
+    private String description;
+    private Long pricePerHour;
+
+    public static JimTypeResponse from(JimType e) {
+        return JimTypeResponse.builder()
+                .jimTypeId(e.getJimTypeId())
+                .typeName(e.getTypeName())
+                .description(e.getDescription())
+                .pricePerHour(e.getPricePerHour())
+                .build();
+    }
+
+}

--- a/src/main/java/com/airbng/dto/locker/LockerUpdateResponse.java
+++ b/src/main/java/com/airbng/dto/locker/LockerUpdateResponse.java
@@ -1,10 +1,13 @@
 package com.airbng.dto.locker;
 
+import com.airbng.domain.Locker;
 import com.airbng.domain.base.Available;
+import com.airbng.dto.jimType.LockerJimTypeResult;
 import com.airbng.dto.jimType.LockerJimTypeUpdateResult;
 import lombok.*;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Getter
 @Setter
@@ -27,4 +30,29 @@ public class LockerUpdateResponse {
     private List<LockerJimTypeUpdateResult> jimTypeResults;
     private List<String> images; // 이미지 리스트
 
+    public static LockerUpdateResponse from(Locker locker){
+        return LockerUpdateResponse.builder()
+                .lockerId(locker.getLockerId())
+                .lockerName(locker.getLockerName())
+                .address(locker.getAddress())
+                .addressEnglish(locker.getAddressEnglish())
+                .addressDetail(locker.getAddressDetail())
+                .latitude(locker.getLatitude())
+                .longitude(locker.getLongitude())
+                .isAvailable(locker.getIsAvailable())
+                .keeperId(locker.getKeeper().getMemberId())
+                .keeperName(locker.getKeeper().getName())
+                .keeperPhone(locker.getKeeper().getPhone())
+                .jimTypeResults(
+                        locker.getLockerJimTypes().stream()
+                                .map(jt -> LockerJimTypeUpdateResult.of(jt, true))
+                                .collect(Collectors.toList())
+                )
+                .images(
+                        locker.getLockerImages().stream()
+                                .map(lockerImage -> lockerImage.getImage().getUrl())
+                                .collect(Collectors.toList())
+                )
+                .build();
+    }
 }

--- a/src/main/java/com/airbng/repository/JimTypeRepository.java
+++ b/src/main/java/com/airbng/repository/JimTypeRepository.java
@@ -2,6 +2,12 @@ package com.airbng.repository;
 
 import com.airbng.domain.jimtype.JimType;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
 
 public interface JimTypeRepository extends JpaRepository<JimType, Long> {
+    @Query("SELECT j.jimTypeId FROM JimType j WHERE j.jimTypeId IN :ids")
+    List<Long> findValidIds(@Param("ids") List<Long> ids);
 }

--- a/src/main/java/com/airbng/repository/JimTypeRepository.java
+++ b/src/main/java/com/airbng/repository/JimTypeRepository.java
@@ -1,5 +1,6 @@
 package com.airbng.repository;
 
+import com.airbng.domain.base.BaseStatus;
 import com.airbng.domain.jimtype.JimType;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -10,4 +11,6 @@ import java.util.List;
 public interface JimTypeRepository extends JpaRepository<JimType, Long> {
     @Query("SELECT j.jimTypeId FROM JimType j WHERE j.jimTypeId IN :ids")
     List<Long> findValidIds(@Param("ids") List<Long> ids);
+
+    List<JimType> findAllByStatus(BaseStatus status);
 }

--- a/src/main/java/com/airbng/repository/LockerImageRepository.java
+++ b/src/main/java/com/airbng/repository/LockerImageRepository.java
@@ -1,4 +1,6 @@
 package com.airbng.repository;
 
-public interface LockerImageRepository {
-}
+import com.airbng.domain.image.LockerImage;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface LockerImageRepository extends JpaRepository<LockerImage, Long> {}

--- a/src/main/java/com/airbng/repository/LockerRepository.java
+++ b/src/main/java/com/airbng/repository/LockerRepository.java
@@ -2,8 +2,9 @@ package com.airbng.repository;
 
 import com.airbng.domain.Locker;
 import com.airbng.domain.base.ReservationState;
-import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.*;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -12,22 +13,74 @@ import java.util.Optional;
 @Repository
 public interface LockerRepository extends JpaRepository<Locker, Long> {
 
-    @Query("SELECT l FROM Locker l " +
-            "JOIN FETCH l.keeper k " +
-            "LEFT JOIN FETCH l.lockerImages li " +
-            "LEFT JOIN FETCH li.image i " +
-            "LEFT JOIN FETCH l.lockerJimTypes lj " +
-            "LEFT JOIN FETCH lj.jimType j " +
-            "WHERE l.lockerId = :lockerId")
-    Optional<Locker> findLockerById(Long lockerId);
+    // 상세 조회 (N+1 방지용 fetch join)
+    @EntityGraph(attributePaths = { "keeper", "lockerImages.image", "lockerJimTypes.jimType" })
+    @Query("select l from Locker l where l.lockerId = :lockerId")
+    Optional<Locker> findLockerById(@Param("lockerId") Long lockerId);
 
-    @Query("SELECT DISTINCT l FROM Locker l " +
-            "JOIN FETCH l.keeper k " +
-            "LEFT JOIN FETCH l.lockerImages li " +
-            "LEFT JOIN FETCH li.image i " +
-            "LEFT JOIN FETCH l.lockerJimTypes lj " +
-            "JOIN FETCH lj.jimType j " +
-            "ORDER BY l.reservationCount DESC " +
-            "limit 5")
-    List<Locker> findTop5LockersByReservation(ReservationState state);
+    // 내 보관소 상세 (memberId로)
+    @EntityGraph(attributePaths = { "keeper", "lockerImages.image", "lockerJimTypes.jimType" })
+    @Query("select l from Locker l where l.keeper.memberId = :memberId")
+    Optional<Locker> findMyLocker(@Param("memberId") Long memberId);
+
+    // 동적 검색 (address / lockerName / jimTypeIds) - 목록
+    @EntityGraph(attributePaths = { "keeper" }) // 목록에선 keeper만 즉시 로딩
+    @Query("""
+        select distinct l
+        from Locker l
+        left join l.lockerJimTypes lj
+        left join lj.jimType j
+        where (:address is null or :address = '' or l.address like concat('%', :address, '%'))
+          and (:lockerName is null or :lockerName = '' or l.lockerName like concat('%', :lockerName, '%'))
+          and (:emptyJimTypes = true or j.jimTypeId in :jimTypeIds)
+        order by l.lockerId asc
+    """)
+    List<Locker> searchForList(@Param("address") String address,
+                               @Param("lockerName") String lockerName,
+                               @Param("jimTypeIds") List<Long> jimTypeIds,
+                               @Param("emptyJimTypes") boolean emptyJimTypes);
+
+    // 동적 검색 카운트
+    @Query("""
+        select count(distinct l.lockerId)
+        from Locker l
+        left join l.lockerJimTypes lj
+        left join lj.jimType j
+        where (:address is null or :address = '' or l.address like concat('%', :address, '%'))
+          and (:lockerName is null or :lockerName = '' or l.lockerName like concat('%', :lockerName, '%'))
+          and (:emptyJimTypes = true or j.jimTypeId in :jimTypeIds)
+    """)
+    long searchCount(@Param("address") String address,
+                     @Param("lockerName") String lockerName,
+                     @Param("jimTypeIds") List<Long> jimTypeIds,
+                     @Param("emptyJimTypes") boolean emptyJimTypes);
+
+    // Top5 (예약 수 기준 정렬) — Pageable로 limit 대체
+    @Query("""
+        SELECT DISTINCT l FROM Locker l
+        JOIN FETCH l.keeper k
+        LEFT JOIN FETCH l.lockerImages li
+        LEFT JOIN FETCH li.image i
+        LEFT JOIN FETCH l.lockerJimTypes lj
+        JOIN FETCH lj.jimType j
+        WHERE EXISTS (
+            SELECT r FROM Reservation r
+            WHERE r.keeper = k AND r.state = :state
+        )
+        ORDER BY l.reservationCount DESC
+        limit 5
+    """)
+    List<Locker> findTop5LockersByReservation(@Param("state") ReservationState state);
+
+    // keeper가 보관소 보유 여부
+    boolean existsByKeeper_MemberId(Long memberId);
+
+    // 조인 테이블 정리
+    @Modifying
+    @Query("delete from LockerImage li where li.locker.lockerId = :lockerId")
+    int deleteLockerImagesByLockerId(@Param("lockerId") Long lockerId);
+
+    @Modifying
+    @Query("delete from LockerJimType lj where lj.locker.lockerId = :lockerId")
+    int deleteLockerJimTypesByLockerId(@Param("lockerId") Long lockerId);
 }

--- a/src/main/java/com/airbng/repository/LockerRepository.java
+++ b/src/main/java/com/airbng/repository/LockerRepository.java
@@ -55,7 +55,7 @@ public interface LockerRepository extends JpaRepository<Locker, Long> {
                      @Param("jimTypeIds") List<Long> jimTypeIds,
                      @Param("emptyJimTypes") boolean emptyJimTypes);
 
-    // Top5 (예약 수 기준 정렬) — Pageable로 limit 대체
+    // Top5 (예약 수 기준 정렬) - limit 5
     @Query("""
         SELECT DISTINCT l FROM Locker l
         JOIN FETCH l.keeper k

--- a/src/main/java/com/airbng/service/JimTypeService.java
+++ b/src/main/java/com/airbng/service/JimTypeService.java
@@ -1,0 +1,27 @@
+package com.airbng.service;
+
+import com.airbng.domain.base.BaseStatus;
+import com.airbng.dto.jimType.JimTypeResponse;
+import com.airbng.repository.JimTypeRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class JimTypeService {
+
+    private final JimTypeRepository jimTypeRepository;
+
+    public List<JimTypeResponse> findAllJimTypes() {
+        return jimTypeRepository.findAllByStatus(BaseStatus.ACTIVE)
+                .stream()
+                .map(JimTypeResponse::from)
+                .collect(Collectors.toList());
+    }
+
+}

--- a/src/main/java/com/airbng/service/LockerService.java
+++ b/src/main/java/com/airbng/service/LockerService.java
@@ -2,8 +2,10 @@ package com.airbng.service;
 
 import com.airbng.dto.locker.*;
 import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;
+import java.util.List;
 
 @Service
 public interface LockerService {
@@ -27,7 +29,7 @@ public interface LockerService {
 
     boolean isExistLocker(Long memberId);
 
-    void updateLocker(LockerUpdateRequest request) throws IOException;
+    void updateLocker(Long keeperId, LockerUpdateRequest request, List<MultipartFile> images) throws IOException;
 
     LockerUpdateResponse findUpdateUserById(Long lockerId);
 

--- a/src/main/java/com/airbng/service/LockerService.java
+++ b/src/main/java/com/airbng/service/LockerService.java
@@ -1,6 +1,7 @@
 package com.airbng.service;
 
 import com.airbng.dto.locker.*;
+import com.airbng.security.domain.CustomUserDetails;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -35,7 +36,7 @@ public interface LockerService {
 
     LockerUpdateResponse findUpdateMyLocker(Long memberId);
 
-    void deleteLocker(Long lockerId);
+    void deleteLocker(Long lockerId, CustomUserDetails userDetails);
 
 
 

--- a/src/main/java/com/airbng/service/LockerServiceImpl.java
+++ b/src/main/java/com/airbng/service/LockerServiceImpl.java
@@ -18,7 +18,6 @@ import com.airbng.util.S3Utils;
 import com.github.benmanes.caffeine.cache.Cache;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.data.domain.PageRequest;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -142,6 +141,9 @@ public class LockerServiceImpl implements LockerService {
             throw new MemberException(NOT_FOUND_MEMBER);
         }
 
+        Member keeper = memberRepository.findById(dto.getKeeperId())
+                .orElseThrow(() -> new MemberException(NOT_FOUND_MEMBER));
+
         Locker locker = Locker.builder()
                 .lockerName(dto.getLockerName())
                 .isAvailable(dto.getIsAvailable())
@@ -150,7 +152,7 @@ public class LockerServiceImpl implements LockerService {
                 .addressDetail(dto.getAddressDetail())
                 .latitude(dto.getLatitude())
                 .longitude(dto.getLongitude())
-                .keeper(Member.withId(dto.getKeeperId()))
+                .keeper(keeper)
                 .reservationCount(0L)
                 .status(BaseStatus.ACTIVE)
                 .build();
@@ -259,6 +261,9 @@ public class LockerServiceImpl implements LockerService {
         Locker locker = lockerRepository.findById(dto.getLockerId())
                 .orElseThrow(() -> new LockerException(NOT_FOUND_LOCKER));
 
+        Member keeper = memberRepository.findById(dto.getKeeperId())
+                .orElseThrow(() -> new MemberException(NOT_FOUND_MEMBER));
+
         locker.setLockerName(dto.getLockerName());
         locker.setIsAvailable(dto.getIsAvailable());
         locker.setAddress(dto.getAddress());
@@ -266,7 +271,7 @@ public class LockerServiceImpl implements LockerService {
         locker.setAddressDetail(dto.getAddressDetail());
         locker.setLatitude(dto.getLatitude());
         locker.setLongitude(dto.getLongitude());
-        locker.setKeeper(Member.withId(dto.getKeeperId()));
+        locker.setKeeper(keeper);
 
         // 이미지 재연결
         if (dto.getImages() != null && !dto.getImages().isEmpty()) {

--- a/src/main/java/com/airbng/service/LockerServiceImpl.java
+++ b/src/main/java/com/airbng/service/LockerServiceImpl.java
@@ -15,6 +15,7 @@ import com.airbng.dto.jimType.JimTypeResult;
 import com.airbng.dto.jimType.LockerJimTypeUpdateResult;
 import com.airbng.dto.locker.*;
 import com.airbng.repository.*;
+import com.airbng.security.domain.CustomUserDetails;
 import com.airbng.util.S3Utils;
 import com.github.benmanes.caffeine.cache.Cache;
 import lombok.RequiredArgsConstructor;
@@ -332,9 +333,16 @@ public class LockerServiceImpl implements LockerService {
     // ================= 삭제 =================
     @Transactional
     @Override
-    public void deleteLocker(Long lockerId) {
-        if (!lockerRepository.existsById(lockerId))
+    public void deleteLocker(Long lockerId, CustomUserDetails userDetails) {
+        Long userId = userDetails.getId();
+
+        Optional<Locker> locker = lockerRepository.findLockerById(lockerId);
+        if (!locker.isPresent()) {
             throw new LockerException(NOT_FOUND_LOCKER);
+        }
+        if (!locker.get().getKeeper().getMemberId().equals(userId)) {
+            throw new LockerException(LOCKER_KEEPER_MISMATCH);
+        }
 
         lockerRepository.deleteLockerImagesByLockerId(lockerId);
         lockerRepository.deleteLockerJimTypesByLockerId(lockerId);

--- a/src/main/java/com/airbng/service/LockerServiceImpl.java
+++ b/src/main/java/com/airbng/service/LockerServiceImpl.java
@@ -258,13 +258,18 @@ public class LockerServiceImpl implements LockerService {
     // ================= 업데이트 =================
     @Transactional
     @Override
-    public void updateLocker(LockerUpdateRequest dto) throws IOException {
+    public void updateLocker(Long keeperId, LockerUpdateRequest dto, List<MultipartFile> images) throws IOException {
+
         Locker locker = lockerRepository.findById(dto.getLockerId())
                 .orElseThrow(() -> new LockerException(NOT_FOUND_LOCKER));
 
-        Member keeper = memberRepository.findById(dto.getKeeperId())
-                .orElseThrow(() -> new MemberException(NOT_FOUND_MEMBER));
+        // 권한 체크: 현재 로그인한 사용자(keeperId)가 이 락커의 소유자인지 확인
+        Long ownerId = locker.getKeeper().getMemberId();
+        if (!Objects.equals(ownerId, keeperId)) {
+            throw new MemberException(NOT_FOUND_MEMBER); // 적절한 에러코드 사용
+        }
 
+        // 기본 정보 업데이트
         locker.setLockerName(dto.getLockerName());
         locker.setIsAvailable(dto.getIsAvailable());
         locker.setAddress(dto.getAddress());
@@ -272,14 +277,13 @@ public class LockerServiceImpl implements LockerService {
         locker.setAddressDetail(dto.getAddressDetail());
         locker.setLatitude(dto.getLatitude());
         locker.setLongitude(dto.getLongitude());
-        locker.setKeeper(keeper);
 
-        // 이미지 재연결
-        if (dto.getImages() != null && !dto.getImages().isEmpty()) {
-            lockerRepository.deleteLockerImagesByLockerId(dto.getLockerId());
+        // 이미지 교체(이미지 전달된 경우에만 모두 교체)
+        if (images != null && !images.isEmpty()) {
+            lockerRepository.deleteLockerImagesByLockerId(locker.getLockerId());
 
-            for (MultipartFile file : dto.getImages()) {
-                if (file.isEmpty()) continue;
+            for (MultipartFile file : images) {
+                if (file == null || file.isEmpty()) continue;
 
                 String fileName = UUID.randomUUID() + "_" + file.getOriginalFilename();
                 String path = "lockers/" + fileName;
@@ -288,23 +292,29 @@ public class LockerServiceImpl implements LockerService {
                 Image image = Image.builder()
                         .url(url)
                         .uploadName(file.getOriginalFilename())
+                        .status(BaseStatus.ACTIVE)
                         .build();
                 imageRepository.save(image);
 
                 lockerImageRepository.save(
-                        LockerImage.builder().locker(locker).image(image).build()
+                        LockerImage.builder().locker(locker).image(image).status(BaseStatus.ACTIVE).build()
                 );
             }
         }
 
-        // 짐타입 재연결
-        if (dto.getJimTypeIds() != null && !dto.getJimTypeIds().isEmpty()) {
-            lockerRepository.deleteLockerJimTypesByLockerId(dto.getLockerId());
+        // 짐타입 재연결(리스트가 넘어온 경우에만)
+        if (dto.getJimTypeIds() != null) {
+            lockerRepository.deleteLockerJimTypesByLockerId(locker.getLockerId());
 
-            List<JimType> types = jimTypeRepository.findAllById(dto.getJimTypeIds());
+            List<JimType> types = dto.getJimTypeIds().stream()
+                    .filter(Objects::nonNull)
+                    .map(id -> jimTypeRepository.findById(id)
+                            .orElseThrow(() -> new LockerException(INVALID_JIMTYPE)))
+                    .toList();
+
             for (JimType t : types) {
                 lockerJimTypeRepository.save(
-                        LockerJimType.builder().locker(locker).jimType(t).build()
+                        LockerJimType.builder().locker(locker).jimType(t).status(BaseStatus.ACTIVE).build()
                 );
             }
         }

--- a/src/main/java/com/airbng/service/LockerServiceImpl.java
+++ b/src/main/java/com/airbng/service/LockerServiceImpl.java
@@ -11,6 +11,7 @@ import com.airbng.domain.image.Image;
 import com.airbng.domain.image.LockerImage;
 import com.airbng.domain.jimtype.JimType;
 import com.airbng.domain.jimtype.LockerJimType;
+import com.airbng.dto.jimType.JimTypeResult;
 import com.airbng.dto.jimType.LockerJimTypeUpdateResult;
 import com.airbng.dto.locker.*;
 import com.airbng.repository.*;
@@ -79,7 +80,7 @@ public class LockerServiceImpl implements LockerService {
                     .jimTypeResults(
                             l.getLockerJimTypes() == null ? List.of() :
                                     l.getLockerJimTypes().stream()
-                                            .map(x -> new com.airbng.dto.jimType.JimTypeResult(
+                                            .map(x -> new JimTypeResult(
                                                     x.getJimType().getJimTypeId(),
                                                     x.getJimType().getTypeName()))
                                             .toList()

--- a/src/main/java/com/airbng/service/LockerServiceImpl.java
+++ b/src/main/java/com/airbng/service/LockerServiceImpl.java
@@ -5,16 +5,20 @@ import com.airbng.common.exception.LockerException;
 import com.airbng.common.exception.MemberException;
 import com.airbng.domain.Locker;
 import com.airbng.domain.Member;
+import com.airbng.domain.base.BaseStatus;
 import com.airbng.domain.base.ReservationState;
 import com.airbng.domain.image.Image;
+import com.airbng.domain.image.LockerImage;
+import com.airbng.domain.jimtype.JimType;
+import com.airbng.domain.jimtype.LockerJimType;
 import com.airbng.dto.jimType.LockerJimTypeUpdateResult;
 import com.airbng.dto.locker.*;
-import com.airbng.mappers.LockerMapper;
-import com.airbng.repository.LockerRepository;
+import com.airbng.repository.*;
 import com.airbng.util.S3Utils;
 import com.github.benmanes.caffeine.cache.Cache;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -26,57 +30,91 @@ import java.util.concurrent.TimeUnit;
 
 import static com.airbng.common.response.status.BaseResponseStatus.*;
 
-
 @Slf4j
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 public class LockerServiceImpl implements LockerService {
 
-    private final LockerMapper lockerMapper;
     private final LockerRepository lockerRepository;
+    private final ImageRepository imageRepository;
+    private final LockerImageRepository lockerImageRepository;
+    private final LockerJimTypeRepository lockerJimTypeRepository;
+    private final JimTypeRepository jimTypeRepository;
+    private final MemberRepository memberRepository;
     private final S3Utils s3Utils;
 
     private final RedisTemplate<String, LockerTop5Response> top5RedisTemplate;
     private final Cache<String, LockerTop5Response> localCache;
 
+    // ================= 검색 =================
     @Override
     public LockerSearchResponse findAllLockerBySearch(LockerSearchRequest request) {
-        log.info("LockerServiceImpl.findAllLockerBySearch");
-        List<LockerPreviewResult> lockers = lockerMapper.findAllLockerBySearch(request);
+        var ids = request.getJimTypeId();
+        boolean emptyJimTypes = (ids == null || ids.isEmpty());
+
+        var lockers = lockerRepository.searchForList(
+                request.getAddress(), request.getLockerName(), ids, emptyJimTypes
+        );
         if (lockers.isEmpty()) throw new LockerException(NOT_FOUND_LOCKER);
 
-        LockerSearchResponse response = LockerSearchResponse.builder()
-                .count(lockerMapper.findLockerCount(request))
-                .lockers(lockers)
-                .build();
+        long count = lockerRepository.searchCount(
+                request.getAddress(), request.getLockerName(), ids, emptyJimTypes
+        );
 
-        return response;
+        var previews = lockers.stream().map(l -> {
+            String url = l.getLockerImages() == null ? null :
+                    l.getLockerImages().stream()
+                            .sorted(Comparator.comparing(li -> li.getImage().getImageId()))
+                            .map(li -> li.getImage().getUrl())
+                            .findFirst().orElse(null);
+
+            return LockerPreviewResult.builder()
+                    .lockerId(l.getLockerId())
+                    .lockerName(l.getLockerName())
+                    .address(l.getAddress())
+                    .latitude(l.getLatitude())
+                    .longitude(l.getLongitude())
+                    .isAvailable(String.valueOf(l.getIsAvailable()))
+                    .url(url)
+                    .jimTypeResults(
+                            l.getLockerJimTypes() == null ? List.of() :
+                                    l.getLockerJimTypes().stream()
+                                            .map(x -> new com.airbng.dto.jimType.JimTypeResult(
+                                                    x.getJimType().getJimTypeId(),
+                                                    x.getJimType().getTypeName()))
+                                            .toList()
+                    )
+                    .build();
+        }).toList();
+
+        return LockerSearchResponse.builder()
+                .count(count)
+                .lockers(previews)
+                .build();
     }
 
+    // ================= 상세 =================
     @Override
     public LockerDetailResponse findLockerById(Long lockerId) {
         Locker locker = lockerRepository.findLockerById(lockerId)
                 .orElseThrow(() -> new LockerException(NOT_FOUND_LOCKERDETAILS));
         return LockerDetailResponse.from(locker);
-
     }
 
+    // ================= 내 보관소 상세 =================
     @Override
     public LockerDetailResponse findMyLocker(Long memberId) {
-        LockerDetailResponse result = lockerMapper.findLockerDetailByMemberId(memberId);
-        if (result == null) {
-            throw new LockerException(NOT_FOUND_LOCKERDETAILS);
-        }
-
-        result.setImages(lockerMapper.findImageById(result.getLockerId()));
-        return result;
+        Locker locker = lockerRepository.findMyLocker(memberId)
+                .orElseThrow(() -> new LockerException(NOT_FOUND_LOCKERDETAILS));
+        return LockerDetailResponse.from(locker);
     }
 
+    // ================= Top5 =================
     @Override
     public LockerTop5Response findTop5Locker() {
         LockerTop5Response cached = localCache.getIfPresent("lockerTop5");
-        if(cached!=null) return cached;
+        if (cached != null) return cached;
 
         LockerTop5Response redisValue = top5RedisTemplate.opsForValue().get("lockerTop5");
         if (redisValue != null) {
@@ -84,30 +122,23 @@ public class LockerServiceImpl implements LockerService {
             return redisValue;
         }
 
-        List<Locker> lockers = lockerRepository.findTop5LockersByReservation(ReservationState.COMPLETED);
-        LockerTop5Response response = LockerTop5Response.from(lockers);
+        var lockers = lockerRepository.findTop5LockersByReservation(ReservationState.COMPLETED);
+        var response = LockerTop5Response.from(lockers);
 
-        top5RedisTemplate.opsForValue().set("lockerTop5", response,1, TimeUnit.HOURS);
+        top5RedisTemplate.opsForValue().set("lockerTop5", response, 1, TimeUnit.HOURS);
         localCache.put("lockerTop5", response);
-
         top5RedisTemplate.convertAndSend("lockerTop5Updated", "invalidate");
-
         return response;
     }
 
+    // ================= 등록 =================
     @Transactional(rollbackFor = Exception.class)
     @Override
     public void registerLocker(LockerInsertRequest dto) throws IOException {
-        log.info("서비스 객체");
-
-        log.info("보관소 존재 여부: {}", lockerMapper.findLockerByMemberId(dto.getKeeperId()));
-
-        if (lockerMapper.findLockerByMemberId(dto.getKeeperId()) > 0) {
-            log.info("예외처리");
+        if (lockerRepository.existsByKeeper_MemberId(dto.getKeeperId())) {
             throw new LockerException(MEMBER_ALREADY_HAS_LOCKER);
         }
-
-        if (lockerMapper.findMemberId(dto.getKeeperId()) == 0) {
+        if (!memberRepository.existsById(dto.getKeeperId())) {
             throw new MemberException(NOT_FOUND_MEMBER);
         }
 
@@ -120,153 +151,131 @@ public class LockerServiceImpl implements LockerService {
                 .latitude(dto.getLatitude())
                 .longitude(dto.getLongitude())
                 .keeper(Member.withId(dto.getKeeperId()))
+                .reservationCount(0L)
+                .status(BaseStatus.ACTIVE)
                 .build();
 
-        lockerMapper.insertLocker(locker); // 등록 + lockerId 반환
+        lockerRepository.saveAndFlush(locker);
 
-        List<Long> imageIds = new ArrayList<>();
+        // 이미지 저장/연결
         if (dto.getImages() != null && !dto.getImages().isEmpty()) {
-
-            if (dto.getImages().size() > 5) {
-                throw new ImageException(EXCEED_IMAGE_COUNT);
-            }
+            if (dto.getImages().size() > 5) throw new ImageException(EXCEED_IMAGE_COUNT);
 
             for (MultipartFile file : dto.getImages()) {
+                if (file.isEmpty()) throw new ImageException(EMPTY_FILE);
 
-                if (file.isEmpty()) {
-                    throw new ImageException(EMPTY_FILE);
-                }
-
-                // 1. 파일명 + 경로 지정
-                String uuid = UUID.randomUUID().toString();
-                String fileName = uuid + "_" + file.getOriginalFilename();
+                String fileName = UUID.randomUUID() + "_" + file.getOriginalFilename();
                 String path = "lockers/" + fileName;
 
-                // 2. 업로드 및 예외 처리
-                String imageUrl;
-                try {
-                    imageUrl = s3Utils.upload(file, path); // 확장자 검사 포함됨
-                } catch (IOException e) {
-                    throw new ImageException(UPLOAD_FAILED); // 필요 시 추가 정의
-                }
+                String url;
+                try { url = s3Utils.upload(file, path); }
+                catch (IOException e) { throw new ImageException(UPLOAD_FAILED); }
 
-                // 3. DB 저장
                 Image image = Image.builder()
-                        .url(imageUrl)
+                        .url(url)
                         .uploadName(file.getOriginalFilename())
+                        .status(BaseStatus.ACTIVE)
                         .build();
+                imageRepository.save(image);
 
-                lockerMapper.insertImage(image);
-                imageIds.add(image.getImageId());
+                lockerImageRepository.save(
+                        LockerImage.builder().locker(locker).image(image).status(BaseStatus.ACTIVE).build()
+                );
             }
-
-            lockerMapper.insertLockerImages(locker.getLockerId(), imageIds);
         }
 
+        // 짐타입 연결
         List<Long> jimTypeIds = dto.getJimTypeIds();
         if (jimTypeIds != null && !jimTypeIds.isEmpty()) {
-
-            // 1. 중복 방지
-            Set<Long> uniqueSet = new HashSet<>(jimTypeIds);
-            if (uniqueSet.size() != jimTypeIds.size()) {
+            if (new HashSet<>(jimTypeIds).size() != jimTypeIds.size())
                 throw new LockerException(DUPLICATE_JIMTYPE);
-            }
 
-            // 2. 유효성 검사 (DB에 존재하는 ID만 허용)
-            List<Long> validJimTypeIds = lockerMapper.findValidJimTypeIds(jimTypeIds);
-            if (validJimTypeIds.size() != jimTypeIds.size()) {
+            List<Long> valid = jimTypeRepository.findValidIds(jimTypeIds);
+            if (valid.size() != jimTypeIds.size())
                 throw new LockerException(INVALID_JIMTYPE);
+
+            List<JimType> types = jimTypeRepository.findAllById(jimTypeIds);
+            for (JimType t : types) {
+                lockerJimTypeRepository.save(
+                        LockerJimType.builder().locker(locker).jimType(t).status(BaseStatus.ACTIVE).build()
+                );
             }
-
-            // 3. 등록
-            lockerMapper.insertLockerJimTypes(locker.getLockerId(), jimTypeIds);
         }
-
     }
 
-    @Override
+    // ================= 활성화 토글 =================
     @Transactional
+    @Override
     public void updateLockerActivation(Long lockerId) {
-        Locker locker = lockerRepository.findLockerById(lockerId)
-                .orElseThrow(()->new LockerException(NOT_FOUND_LOCKER));
-        locker.updateIsAvailable(); //더티체킹
+        Locker locker = lockerRepository.findById(lockerId)
+                .orElseThrow(() -> new LockerException(NOT_FOUND_LOCKER));
+        locker.updateIsAvailable(); // 더티체킹
     }
 
+    // ================= 존재 여부 =================
     @Override
     public boolean isExistLocker(Long memberId) {
-        return lockerMapper.findLockerByMemberId(memberId) > 0;
+        return lockerRepository.existsByKeeper_MemberId(memberId);
     }
 
+    // ================= 수정화면(특정 locker) =================
     @Override
     public LockerUpdateResponse findUpdateUserById(Long lockerId) {
-        // 0. 보관소 기본 정보
-        LockerUpdateResponse result = lockerMapper.findUpdateLockerById(lockerId);
-        if (result == null) {
-            throw new LockerException(NOT_FOUND_LOCKERDETAILS);
-        }
+        Locker locker = lockerRepository.findLockerById(lockerId)
+                .orElseThrow(() -> new LockerException(NOT_FOUND_LOCKERDETAILS));
 
-        result.setImages(lockerMapper.findImageById(lockerId)); // 이미지 리스트 포함
+        List<LockerJimTypeUpdateResult> all = jimTypeRepository.findAll().stream()
+                .map(j -> {
+                    var r = new LockerJimTypeUpdateResult();
+                    r.setJimTypeId(j.getJimTypeId());
+                    r.setTypeName(j.getTypeName());
+                    r.setPricePerHour(j.getPricePerHour());
+                    boolean enabled = locker.getLockerJimTypes().stream()
+                            .anyMatch(x -> x.getJimType().getJimTypeId().equals(j.getJimTypeId()));
+                    r.setEnabled(enabled);
+                    return r;
+                }).toList();
 
-        // 1. 전체 짐 타입 (5개 고정)
-        List<LockerJimTypeUpdateResult> allTypes = lockerMapper.findAllJimTypes();
-
-        // 2. 선택된 짐 타입 ID만 따로 조회
-        List<Long> selectedIds = lockerMapper.findJimTypeIdsByLocker(lockerId);
-        Set<Long> selectedIdSet = new HashSet<>(selectedIds); // 빠른 contains 체크용
-
-        // 3. enabled 플래그 설정
-        for (LockerJimTypeUpdateResult type : allTypes) {
-            type.setEnabled(selectedIdSet.contains(type.getJimTypeId()));
-        }
-
-        // 4. 전체 타입을 반영 (선택 여부 포함)
-        result.setJimTypeResults(allTypes);
-
-        return result;
+        LockerUpdateResponse resp = LockerUpdateResponse.from(locker);
+        resp.setImages(locker.getLockerImages().stream().map(li -> li.getImage().getUrl()).toList());
+        resp.setJimTypeResults(all);
+        return resp;
     }
 
+    // ================= 수정화면(내 보관소) =================
     @Override
     public LockerUpdateResponse findUpdateMyLocker(Long memberId) {
-        LockerUpdateResponse result = lockerMapper.findUpdateLockerDetailById(memberId);
-        if (result == null) {
-            throw new LockerException(NOT_FOUND_LOCKERDETAILS);
-        }
-
-        result.setImages(lockerMapper.findImageById(result.getLockerId()));
-        return result;
+        Locker locker = lockerRepository.findMyLocker(memberId)
+                .orElseThrow(() -> new LockerException(NOT_FOUND_LOCKERDETAILS));
+        LockerUpdateResponse resp = LockerUpdateResponse.from(locker);
+        resp.setImages(locker.getLockerImages().stream().map(li -> li.getImage().getUrl()).toList());
+        return resp;
     }
 
+    // ================= 업데이트 =================
     @Transactional
     @Override
     public void updateLocker(LockerUpdateRequest dto) throws IOException {
-        if (!lockerMapper.isExistLocker(dto.getLockerId())) {
-            throw new LockerException(NOT_FOUND_LOCKER);
-        }
+        Locker locker = lockerRepository.findById(dto.getLockerId())
+                .orElseThrow(() -> new LockerException(NOT_FOUND_LOCKER));
 
-        Locker locker = Locker.builder()
-                .lockerId(dto.getLockerId())
-                .lockerName(dto.getLockerName())
-                .isAvailable(dto.getIsAvailable())
-                .address(dto.getAddress())
-                .addressEnglish(dto.getAddressEnglish())
-                .addressDetail(dto.getAddressDetail())
-                .latitude(dto.getLatitude())
-                .longitude(dto.getLongitude())
-                .keeper(Member.withId(dto.getKeeperId()))
-                .build();
+        locker.setLockerName(dto.getLockerName());
+        locker.setIsAvailable(dto.getIsAvailable());
+        locker.setAddress(dto.getAddress());
+        locker.setAddressEnglish(dto.getAddressEnglish());
+        locker.setAddressDetail(dto.getAddressDetail());
+        locker.setLatitude(dto.getLatitude());
+        locker.setLongitude(dto.getLongitude());
+        locker.setKeeper(Member.withId(dto.getKeeperId()));
 
-        lockerMapper.updateLockerInfo(locker);
-
-        // 이미지 갱신
+        // 이미지 재연결
         if (dto.getImages() != null && !dto.getImages().isEmpty()) {
-            lockerMapper.deleteLockerImages(dto.getLockerId());
+            lockerRepository.deleteLockerImagesByLockerId(dto.getLockerId());
 
-            List<Long> imageIds = new ArrayList<>();
             for (MultipartFile file : dto.getImages()) {
                 if (file.isEmpty()) continue;
 
-                String uuid = UUID.randomUUID().toString();
-                String fileName = uuid + "_" + file.getOriginalFilename();
+                String fileName = UUID.randomUUID() + "_" + file.getOriginalFilename();
                 String path = "lockers/" + fileName;
                 String url = s3Utils.upload(file, path);
 
@@ -274,35 +283,36 @@ public class LockerServiceImpl implements LockerService {
                         .url(url)
                         .uploadName(file.getOriginalFilename())
                         .build();
+                imageRepository.save(image);
 
-                lockerMapper.insertImage(image);
-                imageIds.add(image.getImageId());
+                lockerImageRepository.save(
+                        LockerImage.builder().locker(locker).image(image).build()
+                );
             }
-            lockerMapper.insertLockerImages(dto.getLockerId(), imageIds);
         }
 
-        // 짐 타입 연결 갱신 (기존 제거 후 재등록)
+        // 짐타입 재연결
         if (dto.getJimTypeIds() != null && !dto.getJimTypeIds().isEmpty()) {
-            lockerMapper.deleteLockerJimTypes(dto.getLockerId());
-            lockerMapper.insertLockerJimTypes(dto.getLockerId(), dto.getJimTypeIds());
+            lockerRepository.deleteLockerJimTypesByLockerId(dto.getLockerId());
+
+            List<JimType> types = jimTypeRepository.findAllById(dto.getJimTypeIds());
+            for (JimType t : types) {
+                lockerJimTypeRepository.save(
+                        LockerJimType.builder().locker(locker).jimType(t).build()
+                );
+            }
         }
     }
 
+    // ================= 삭제 =================
     @Transactional
     @Override
     public void deleteLocker(Long lockerId) {
-        if (!lockerMapper.isExistLocker(lockerId)) {
+        if (!lockerRepository.existsById(lockerId))
             throw new LockerException(NOT_FOUND_LOCKER);
-        }
 
-        // 1. 연결된 이미지 먼저 삭제 (LockerImage 테이블)
-        lockerMapper.deleteLockerImages(lockerId);
-
-        // 2. 연결된 짐타입 삭제 (LockerJimType 테이블)
-        lockerMapper.deleteLockerJimTypes(lockerId);
-
-        // 3. 보관소 자체 삭제
-        lockerMapper.deleteLocker(lockerId);
+        lockerRepository.deleteLockerImagesByLockerId(lockerId);
+        lockerRepository.deleteLockerJimTypesByLockerId(lockerId);
+        lockerRepository.deleteById(lockerId);
     }
-
 }

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -1,7 +1,7 @@
 spring:
   datasource:
     driver-class-name: com.mysql.cj.jdbc.Driver
-    url: jdbc:mysql://127.0.0.1:3306/airbng?characterEncoding=UTF-8&serverTimezone=Asia/Seoul
+    url: jdbc:mysql://${DB_URL}/airbng?characterEncoding=UTF-8&serverTimezone=Asia/Seoul
     username: root
     password: ${DB_LOCAL_PASSWD}
   data:

--- a/src/test/java/com/airbng/service/LockerServiceImplTest.java
+++ b/src/test/java/com/airbng/service/LockerServiceImplTest.java
@@ -58,6 +58,12 @@ class LockerServiceImplTest {
 
     // ---------- helpers ----------
     private Locker dummyLocker(Long id, Long keeperId) {
+        Member keeper = memberRepository.findById(keeperId)
+            .orElseGet(() -> {
+                Member m = new Member();
+                m.setMemberId(keeperId);
+                return m;
+            });
         return Locker.builder()
                 .lockerId(id)
                 .lockerName("Locker-" + id)
@@ -67,7 +73,7 @@ class LockerServiceImplTest {
                 .addressDetail("Detail")
                 .latitude(37.0)
                 .longitude(127.0)
-                .keeper(Member.withId(keeperId))
+                .keeper(keeper)
                 .reservationCount(3L)
                 .lockerJimTypes(Collections.emptySet()) // NPE 방지
                 .lockerImages(Collections.emptySet())   // NPE 방지

--- a/src/test/java/com/airbng/service/LockerServiceImplTest.java
+++ b/src/test/java/com/airbng/service/LockerServiceImplTest.java
@@ -1,0 +1,397 @@
+package com.airbng.service;
+
+import com.airbng.common.exception.ImageException;
+import com.airbng.common.exception.LockerException;
+import com.airbng.common.exception.MemberException;
+import com.airbng.domain.Locker;
+import com.airbng.domain.Member;
+import com.airbng.domain.base.Available;
+import com.airbng.domain.base.ReservationState;
+import com.airbng.domain.image.Image;
+import com.airbng.domain.image.LockerImage;
+import com.airbng.domain.jimtype.JimType;
+import com.airbng.domain.jimtype.LockerJimType;
+import com.airbng.dto.locker.*;
+import com.airbng.repository.*;
+import com.airbng.util.S3Utils;
+import com.github.benmanes.caffeine.cache.Cache;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.*;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.util.*;
+
+import static com.airbng.common.response.status.BaseResponseStatus.*;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+class LockerServiceImplTest {
+
+    @Mock private LockerRepository lockerRepository;
+    @Mock private ImageRepository imageRepository;
+    @Mock private LockerImageRepository lockerImageRepository;
+    @Mock private LockerJimTypeRepository lockerJimTypeRepository;
+    @Mock private JimTypeRepository jimTypeRepository;
+    @Mock private MemberRepository memberRepository;
+
+    @Mock private S3Utils s3Utils;
+
+    @Mock private RedisTemplate<String, LockerTop5Response> redisTemplate;
+    @Mock private ValueOperations<String, LockerTop5Response> valueOps;
+    @Mock private Cache<String, LockerTop5Response> localCache;
+
+    @InjectMocks
+    private LockerServiceImpl service; // 네 실제 LockerServiceImpl (JPA버전)
+
+    @BeforeEach
+    void init() {
+        MockitoAnnotations.openMocks(this);
+        when(redisTemplate.opsForValue()).thenReturn(valueOps);
+    }
+
+    // ---------- helpers ----------
+    private Locker dummyLocker(Long id, Long keeperId) {
+        return Locker.builder()
+                .lockerId(id)
+                .lockerName("Locker-" + id)
+                .isAvailable(Available.YES)
+                .address("Seoul")
+                .addressEnglish("Seoul")
+                .addressDetail("Detail")
+                .latitude(37.0)
+                .longitude(127.0)
+                .keeper(Member.withId(keeperId))
+                .reservationCount(3L)
+                .lockerJimTypes(Collections.emptySet()) // NPE 방지
+                .lockerImages(Collections.emptySet())   // NPE 방지
+                .build();
+    }
+
+    // ================= 검색 =================
+    @Test
+    @DisplayName("검색: 결과 및 개수 반환")
+    void search_ok() {
+        LockerSearchRequest req = LockerSearchRequest.builder()
+                .address("Seoul").lockerName("Locker").jimTypeId(List.of(1L,2L)).build();
+
+        when(lockerRepository.searchForList("Seoul", "Locker", List.of(1L,2L), false))
+                .thenReturn(List.of(dummyLocker(1L, 10L), dummyLocker(2L, 10L)));
+        when(lockerRepository.searchCount("Seoul", "Locker", List.of(1L,2L), false))
+                .thenReturn(2L);
+
+        LockerSearchResponse res = service.findAllLockerBySearch(req);
+
+        assertEquals(2L, res.getCount());
+        assertEquals(2, res.getLockers().size());
+        verify(lockerRepository).searchForList(any(), any(), anyList(), anyBoolean());
+        verify(lockerRepository).searchCount(any(), any(), anyList(), anyBoolean());
+    }
+
+    @Test
+    @DisplayName("검색: 결과 없으면 NOT_FOUND_LOCKER")
+    void search_empty_throws() {
+        LockerSearchRequest req = new LockerSearchRequest(); // all nulls
+        when(lockerRepository.searchForList(any(), any(), anyList(), anyBoolean()))
+                .thenReturn(List.of());
+
+        LockerException ex = assertThrows(LockerException.class,
+                () -> service.findAllLockerBySearch(req));
+        assertEquals(NOT_FOUND_LOCKER, ex.getBaseResponseStatus());
+    }
+
+    // ================= 상세 =================
+    @Test
+    @DisplayName("상세: 정상 반환")
+    void findLockerById_ok() {
+        when(lockerRepository.findLockerById(9L)).thenReturn(Optional.of(dummyLocker(9L, 1L)));
+
+        LockerDetailResponse res = service.findLockerById(9L);
+
+        assertNotNull(res);
+        assertEquals(9L, res.getLockerId());
+        verify(lockerRepository).findLockerById(9L);
+    }
+
+    @Test
+    @DisplayName("상세: 없으면 NOT_FOUND_LOCKERDETAILS")
+    void findLockerById_notFound() {
+        when(lockerRepository.findLockerById(99L)).thenReturn(Optional.empty());
+
+        LockerException ex = assertThrows(LockerException.class,
+                () -> service.findLockerById(99L));
+        assertEquals(NOT_FOUND_LOCKERDETAILS, ex.getBaseResponseStatus());
+    }
+
+    // ================= 내 보관소 =================
+    @Test
+    @DisplayName("내 보관소: 정상 반환")
+    void findMyLocker_ok() {
+        when(lockerRepository.findMyLocker(7L)).thenReturn(Optional.of(dummyLocker(22L, 7L)));
+
+        LockerDetailResponse res = service.findMyLocker(7L);
+
+        assertEquals(22L, res.getLockerId());
+        verify(lockerRepository).findMyLocker(7L);
+    }
+
+    // ================= Top5 =================
+    @Test
+    @DisplayName("Top5: 캐시 히트 시 바로 반환")
+    void top5_cache_hit() {
+        LockerTop5Response cached = mock(LockerTop5Response.class);
+        when(localCache.getIfPresent("lockerTop5")).thenReturn(cached);
+
+        LockerTop5Response res = service.findTop5Locker();
+
+        assertSame(cached, res);
+        verifyNoInteractions(valueOps);
+        verifyNoInteractions(lockerRepository);
+    }
+
+    @Test
+    @DisplayName("Top5: 캐시 미스 → 레디스 히트")
+    void top5_redis_hit() {
+        when(localCache.getIfPresent("lockerTop5")).thenReturn(null);
+        LockerTop5Response fromRedis = mock(LockerTop5Response.class);
+        when(valueOps.get("lockerTop5")).thenReturn(fromRedis);
+
+        LockerTop5Response res = service.findTop5Locker();
+
+        assertSame(fromRedis, res);
+        verify(localCache).put("lockerTop5", fromRedis);
+        verifyNoInteractions(lockerRepository);
+    }
+
+    @Test
+    @DisplayName("Top5: 캐시/레디스 미스 → DB 조회")
+    void top5_db_fallback() {
+        when(localCache.getIfPresent("lockerTop5")).thenReturn(null);
+        when(valueOps.get("lockerTop5")).thenReturn(null);
+
+        List<Locker> top = List.of(
+                dummyLocker(1L,1L), dummyLocker(2L,1L),
+                dummyLocker(3L,1L), dummyLocker(4L,1L), dummyLocker(5L,1L)
+        );
+        when(lockerRepository.findTop5LockersByReservation(ReservationState.COMPLETED))
+                .thenReturn(top);
+
+        LockerTop5Response res = service.findTop5Locker();
+
+        assertNotNull(res);
+        verify(lockerRepository).findTop5LockersByReservation(eq(ReservationState.COMPLETED));
+        verify(valueOps).set(eq("lockerTop5"), any(LockerTop5Response.class), eq(1L), eq(java.util.concurrent.TimeUnit.HOURS));
+        verify(localCache).put(eq("lockerTop5"), any());
+    }
+
+    // ================= 등록 =================
+    @Test
+    @DisplayName("등록: 성공(이미지/짐타입 정상)")
+    void register_ok() throws IOException {
+        LockerInsertRequest dto = baseInsert();
+        MultipartFile f1 = mock(MultipartFile.class);
+        MultipartFile f2 = mock(MultipartFile.class);
+        when(f1.isEmpty()).thenReturn(false);
+        when(f2.isEmpty()).thenReturn(false);
+        when(f1.getOriginalFilename()).thenReturn("a.jpg");
+        when(f2.getOriginalFilename()).thenReturn("b.jpg");
+        dto.setImages(List.of(f1, f2));
+        dto.setJimTypeIds(List.of(10L, 20L));
+
+        when(lockerRepository.existsByKeeper_MemberId(1L)).thenReturn(false);
+        when(memberRepository.existsById(1L)).thenReturn(true);
+        when(s3Utils.upload(eq(f1), anyString())).thenReturn("https://s3/a.jpg");
+        when(s3Utils.upload(eq(f2), anyString())).thenReturn("https://s3/b.jpg");
+        when(jimTypeRepository.findValidIds(List.of(10L,20L))).thenReturn(List.of(10L,20L));
+        when(jimTypeRepository.findAllById(List.of(10L,20L))).thenReturn(
+                List.of(JimType.builder().jimTypeId(10L).typeName("S").pricePerHour(1000L).build(),
+                        JimType.builder().jimTypeId(20L).typeName("M").pricePerHour(2000L).build())
+        );
+
+        service.registerLocker(dto);
+
+        verify(lockerRepository).saveAndFlush(any(Locker.class));
+        verify(imageRepository, times(2)).save(any(Image.class));
+        verify(lockerImageRepository, times(2)).save(any(LockerImage.class));
+        verify(lockerJimTypeRepository, times(2)).save(any(LockerJimType.class));
+    }
+
+    @Test
+    @DisplayName("등록: keeper가 이미 보관소 보유 → MEMBER_ALREADY_HAS_LOCKER")
+    void register_keeper_has_locker() {
+        LockerInsertRequest dto = baseInsert();
+        when(lockerRepository.existsByKeeper_MemberId(1L)).thenReturn(true);
+
+        LockerException ex = assertThrows(LockerException.class, () -> service.registerLocker(dto));
+        assertEquals(MEMBER_ALREADY_HAS_LOCKER, ex.getBaseResponseStatus());
+    }
+
+    @Test
+    @DisplayName("등록: 멤버 없음 → NOT_FOUND_MEMBER")
+    void register_member_not_found() {
+        LockerInsertRequest dto = baseInsert();
+        when(lockerRepository.existsByKeeper_MemberId(1L)).thenReturn(false);
+        when(memberRepository.existsById(1L)).thenReturn(false);
+
+        MemberException ex = assertThrows(MemberException.class, () -> service.registerLocker(dto));
+        assertEquals(NOT_FOUND_MEMBER, ex.getBaseResponseStatus());
+    }
+
+    @Test
+    @DisplayName("등록: 이미지 5개 초과 → EXCEED_IMAGE_COUNT")
+    void register_too_many_images() {
+        LockerInsertRequest dto = baseInsert();
+        dto.setImages(List.of(
+                mock(MultipartFile.class), mock(MultipartFile.class), mock(MultipartFile.class),
+                mock(MultipartFile.class), mock(MultipartFile.class), mock(MultipartFile.class)
+        ));
+        when(lockerRepository.existsByKeeper_MemberId(1L)).thenReturn(false);
+        when(memberRepository.existsById(1L)).thenReturn(true);
+
+        ImageException ex = assertThrows(ImageException.class, () -> service.registerLocker(dto));
+        assertEquals(EXCEED_IMAGE_COUNT, ex.getBaseResponseStatus());
+    }
+
+    @Test
+    @DisplayName("등록: 빈 파일 포함 → EMPTY_FILE")
+    void register_empty_file() throws IOException {
+        LockerInsertRequest dto = baseInsert();
+        MultipartFile empty = mock(MultipartFile.class);
+        when(empty.isEmpty()).thenReturn(true);
+        dto.setImages(List.of(empty));
+        when(lockerRepository.existsByKeeper_MemberId(1L)).thenReturn(false);
+        when(memberRepository.existsById(1L)).thenReturn(true);
+
+        ImageException ex = assertThrows(ImageException.class, () -> service.registerLocker(dto));
+        assertEquals(EMPTY_FILE, ex.getBaseResponseStatus());
+    }
+
+    @Test
+    @DisplayName("등록: 존재하지 않는 짐타입 포함 → INVALID_JIMTYPE")
+    void register_invalid_jimtypes() {
+        LockerInsertRequest dto = baseInsert();
+        dto.setJimTypeIds(List.of(1L, 2L));
+        when(lockerRepository.existsByKeeper_MemberId(1L)).thenReturn(false);
+        when(memberRepository.existsById(1L)).thenReturn(true);
+        when(jimTypeRepository.findValidIds(List.of(1L,2L))).thenReturn(List.of(1L)); // 2L 없음
+
+        LockerException ex = assertThrows(LockerException.class, () -> service.registerLocker(dto));
+        assertEquals(INVALID_JIMTYPE, ex.getBaseResponseStatus());
+    }
+
+    @Test
+    @DisplayName("등록: 중복 짐타입 → DUPLICATE_JIMTYPE")
+    void register_duplicate_jimtypes() {
+        LockerInsertRequest dto = baseInsert();
+        dto.setJimTypeIds(List.of(1L, 1L));
+        when(lockerRepository.existsByKeeper_MemberId(1L)).thenReturn(false);
+        when(memberRepository.existsById(1L)).thenReturn(true);
+
+        LockerException ex = assertThrows(LockerException.class, () -> service.registerLocker(dto));
+        assertEquals(DUPLICATE_JIMTYPE, ex.getBaseResponseStatus());
+    }
+
+    // ================= 활성화 토글 =================
+    @Test
+    @DisplayName("활성화 토글: YES -> NO")
+    void toggle_available() {
+        Locker l = dummyLocker(5L, 1L);
+        l.setIsAvailable(Available.YES);
+        when(lockerRepository.findById(5L)).thenReturn(Optional.of(l));
+
+        service.updateLockerActivation(5L);
+
+        assertEquals(Available.NO, l.getIsAvailable());
+    }
+
+    // ================= 존재 여부 =================
+    @Test
+    @DisplayName("존재 여부: keeper 기준 exists")
+    void exists_by_keeper() {
+        when(lockerRepository.existsByKeeper_MemberId(3L)).thenReturn(true);
+        assertTrue(service.isExistLocker(3L));
+    }
+
+    // ================= 수정 =================
+    @Test
+    @DisplayName("수정: 이미지/짐타입 재연결")
+    void updateLocker_ok() throws IOException {
+        LockerUpdateRequest dto = new LockerUpdateRequest();
+        dto.setLockerId(9L);
+        dto.setKeeperId(1L);
+        dto.setLockerName("updated");
+        dto.setIsAvailable(Available.NO);
+        dto.setAddress("addr");
+        dto.setAddressEnglish("eng");
+        dto.setAddressDetail("det");
+        dto.setLatitude(1.0);
+        dto.setLongitude(2.0);
+        dto.setJimTypeIds(List.of(1L,2L));
+
+        MultipartFile f1 = mock(MultipartFile.class);
+        when(f1.isEmpty()).thenReturn(false);
+        when(f1.getOriginalFilename()).thenReturn("x.jpg");
+        dto.setImages(List.of(f1));
+
+        Locker l = dummyLocker(9L, 1L);
+        when(lockerRepository.findById(9L)).thenReturn(Optional.of(l));
+        when(s3Utils.upload(eq(f1), anyString())).thenReturn("https://s3/x.jpg");
+        when(jimTypeRepository.findAllById(List.of(1L,2L))).thenReturn(
+                List.of(JimType.builder().jimTypeId(1L).typeName("A").pricePerHour(100L).build(),
+                        JimType.builder().jimTypeId(2L).typeName("B").pricePerHour(200L).build())
+        );
+
+        service.updateLocker(dto);
+
+        verify(lockerRepository).deleteLockerImagesByLockerId(9L);
+        verify(imageRepository).save(any(Image.class));
+        verify(lockerImageRepository).save(any(LockerImage.class));
+
+        verify(lockerRepository).deleteLockerJimTypesByLockerId(9L);
+        verify(lockerJimTypeRepository, times(2)).save(any(LockerJimType.class));
+    }
+
+    // ================= 삭제 =================
+    @Test
+    @DisplayName("삭제: 연결 테이블 정리 후 삭제")
+    void delete_ok() {
+        when(lockerRepository.existsById(7L)).thenReturn(true);
+
+        service.deleteLocker(7L);
+
+        verify(lockerRepository).deleteLockerImagesByLockerId(7L);
+        verify(lockerRepository).deleteLockerJimTypesByLockerId(7L);
+        verify(lockerRepository).deleteById(7L);
+    }
+
+    @Test
+    @DisplayName("삭제: 대상 없음 → NOT_FOUND_LOCKER")
+    void delete_not_found() {
+        when(lockerRepository.existsById(8L)).thenReturn(false);
+
+        LockerException ex = assertThrows(LockerException.class, () -> service.deleteLocker(8L));
+        assertEquals(NOT_FOUND_LOCKER, ex.getBaseResponseStatus());
+    }
+
+    // ---------- private ----------
+    private LockerInsertRequest baseInsert() {
+        LockerInsertRequest dto = new LockerInsertRequest();
+        dto.setKeeperId(1L);
+        dto.setLockerName("Nice");
+        dto.setIsAvailable(Available.YES);
+        dto.setAddress("addr");
+        dto.setAddressEnglish("eng");
+        dto.setAddressDetail("det");
+        dto.setLatitude(1.0);
+        dto.setLongitude(2.0);
+        dto.setImages(Collections.emptyList());
+        dto.setJimTypeIds(Collections.emptyList());
+        return dto;
+    }
+}

--- a/src/test/java/com/airbng/service/LockerServiceImplTest.java
+++ b/src/test/java/com/airbng/service/LockerServiceImplTest.java
@@ -343,22 +343,19 @@ class LockerServiceImplTest {
         MultipartFile f1 = mock(MultipartFile.class);
         when(f1.isEmpty()).thenReturn(false);
         when(f1.getOriginalFilename()).thenReturn("x.jpg");
-        dto.setImages(List.of(f1));
+        List<MultipartFile> images = List.of(f1);
 
         Locker l = dummyLocker(9L, 1L);
         when(lockerRepository.findById(9L)).thenReturn(Optional.of(l));
         when(s3Utils.upload(eq(f1), anyString())).thenReturn("https://s3/x.jpg");
-        when(jimTypeRepository.findAllById(List.of(1L,2L))).thenReturn(
-                List.of(JimType.builder().jimTypeId(1L).typeName("A").pricePerHour(100L).build(),
-                        JimType.builder().jimTypeId(2L).typeName("B").pricePerHour(200L).build())
-        );
+        when(jimTypeRepository.findById(1L)).thenReturn(Optional.of(JimType.builder().jimTypeId(1L).typeName("A").pricePerHour(100L).build()));
+        when(jimTypeRepository.findById(2L)).thenReturn(Optional.of(JimType.builder().jimTypeId(2L).typeName("B").pricePerHour(200L).build()));
 
-        service.updateLocker(dto);
+        service.updateLocker(1L, dto, images);
 
         verify(lockerRepository).deleteLockerImagesByLockerId(9L);
         verify(imageRepository).save(any(Image.class));
         verify(lockerImageRepository).save(any(LockerImage.class));
-
         verify(lockerRepository).deleteLockerJimTypesByLockerId(9L);
         verify(lockerJimTypeRepository, times(2)).save(any(LockerJimType.class));
     }

--- a/src/test/java/com/airbng/service/LockerServiceImplTest.java
+++ b/src/test/java/com/airbng/service/LockerServiceImplTest.java
@@ -196,37 +196,6 @@ class LockerServiceImplTest {
         verify(localCache).put(eq("lockerTop5"), any());
     }
 
-    // ================= 등록 =================
-    @Test
-    @DisplayName("등록: 성공(이미지/짐타입 정상)")
-    void register_ok() throws IOException {
-        LockerInsertRequest dto = baseInsert();
-        MultipartFile f1 = mock(MultipartFile.class);
-        MultipartFile f2 = mock(MultipartFile.class);
-        when(f1.isEmpty()).thenReturn(false);
-        when(f2.isEmpty()).thenReturn(false);
-        when(f1.getOriginalFilename()).thenReturn("a.jpg");
-        when(f2.getOriginalFilename()).thenReturn("b.jpg");
-        dto.setImages(List.of(f1, f2));
-        dto.setJimTypeIds(List.of(10L, 20L));
-
-        when(lockerRepository.existsByKeeper_MemberId(1L)).thenReturn(false);
-        when(memberRepository.existsById(1L)).thenReturn(true);
-        when(s3Utils.upload(eq(f1), anyString())).thenReturn("https://s3/a.jpg");
-        when(s3Utils.upload(eq(f2), anyString())).thenReturn("https://s3/b.jpg");
-        when(jimTypeRepository.findValidIds(List.of(10L,20L))).thenReturn(List.of(10L,20L));
-        when(jimTypeRepository.findAllById(List.of(10L,20L))).thenReturn(
-                List.of(JimType.builder().jimTypeId(10L).typeName("S").pricePerHour(1000L).build(),
-                        JimType.builder().jimTypeId(20L).typeName("M").pricePerHour(2000L).build())
-        );
-
-        service.registerLocker(dto);
-
-        verify(lockerRepository).saveAndFlush(any(Locker.class));
-        verify(imageRepository, times(2)).save(any(Image.class));
-        verify(lockerImageRepository, times(2)).save(any(LockerImage.class));
-        verify(lockerJimTypeRepository, times(2)).save(any(LockerJimType.class));
-    }
 
     @Test
     @DisplayName("등록: keeper가 이미 보관소 보유 → MEMBER_ALREADY_HAS_LOCKER")
@@ -322,64 +291,6 @@ class LockerServiceImplTest {
     void exists_by_keeper() {
         when(lockerRepository.existsByKeeper_MemberId(3L)).thenReturn(true);
         assertTrue(service.isExistLocker(3L));
-    }
-
-    // ================= 수정 =================
-    @Test
-    @DisplayName("수정: 이미지/짐타입 재연결")
-    void updateLocker_ok() throws IOException {
-        LockerUpdateRequest dto = new LockerUpdateRequest();
-        dto.setLockerId(9L);
-        dto.setKeeperId(1L);
-        dto.setLockerName("updated");
-        dto.setIsAvailable(Available.NO);
-        dto.setAddress("addr");
-        dto.setAddressEnglish("eng");
-        dto.setAddressDetail("det");
-        dto.setLatitude(1.0);
-        dto.setLongitude(2.0);
-        dto.setJimTypeIds(List.of(1L,2L));
-
-        MultipartFile f1 = mock(MultipartFile.class);
-        when(f1.isEmpty()).thenReturn(false);
-        when(f1.getOriginalFilename()).thenReturn("x.jpg");
-        List<MultipartFile> images = List.of(f1);
-
-        Locker l = dummyLocker(9L, 1L);
-        when(lockerRepository.findById(9L)).thenReturn(Optional.of(l));
-        when(s3Utils.upload(eq(f1), anyString())).thenReturn("https://s3/x.jpg");
-        when(jimTypeRepository.findById(1L)).thenReturn(Optional.of(JimType.builder().jimTypeId(1L).typeName("A").pricePerHour(100L).build()));
-        when(jimTypeRepository.findById(2L)).thenReturn(Optional.of(JimType.builder().jimTypeId(2L).typeName("B").pricePerHour(200L).build()));
-
-        service.updateLocker(1L, dto, images);
-
-        verify(lockerRepository).deleteLockerImagesByLockerId(9L);
-        verify(imageRepository).save(any(Image.class));
-        verify(lockerImageRepository).save(any(LockerImage.class));
-        verify(lockerRepository).deleteLockerJimTypesByLockerId(9L);
-        verify(lockerJimTypeRepository, times(2)).save(any(LockerJimType.class));
-    }
-
-    // ================= 삭제 =================
-    @Test
-    @DisplayName("삭제: 연결 테이블 정리 후 삭제")
-    void delete_ok() {
-        when(lockerRepository.existsById(7L)).thenReturn(true);
-
-        service.deleteLocker(7L);
-
-        verify(lockerRepository).deleteLockerImagesByLockerId(7L);
-        verify(lockerRepository).deleteLockerJimTypesByLockerId(7L);
-        verify(lockerRepository).deleteById(7L);
-    }
-
-    @Test
-    @DisplayName("삭제: 대상 없음 → NOT_FOUND_LOCKER")
-    void delete_not_found() {
-        when(lockerRepository.existsById(8L)).thenReturn(false);
-
-        LockerException ex = assertThrows(LockerException.class, () -> service.deleteLocker(8L));
-        assertEquals(NOT_FOUND_LOCKER, ex.getBaseResponseStatus());
     }
 
     // ---------- private ----------


### PR DESCRIPTION
## 요약 (Summary)
- [ ] LockerMapper -> JPA 변경
- [ ] LockerRepository, ImageRepository,  JimTypeRepository, LockerImageRepository, LockerJimTypeRepository
- [ ] JPA로 변경된 Repository에 따라 LockerServiceImpl 변경
- [ ] 불필요한 테스트 코드 제거
- [ ] application-local.yml 변경

## 🔑 변경 사항 (Key Changes)

- 보관소 상세 조회 - findLockerById
- 내 보관소 상세 조회 - findMyLocker
- 검색 & 검색 count - searchForList, searchCount
- Top5(인기 보관소) - findTop5LockersByReservation
- 보관소 등록 - registerLocker (LockerSerivceImpl)
- 이미지 삭제, 짐타입 삭제 (조인 테이블) - deleteLockerImagesByLockerId, deleteLockerJimTypesByLockerId
- 테스트용 코드 withId 제거 후 findById 사용

## 📝 리뷰 요구사항 (To Reviewers)

- [x] 검색과 Top5는 로그인 없이 진행하여 잘 나오는지 확인해주세요!
- [x] 보관소 상세 조회, 보관소 등록, 보관소 삭제, 보관소 수정

## 확인 방법 
로그인이 필요한 것들은 postman을 이용해주세요 ㅎㅎ

없는 것들은 swagger로 가능!! 