### PR TITLE
[#127] 회원정보 조회 수정 jpa로 변환

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,6 +46,7 @@ src/main/webapp/js/config/
 .bin/
 .bin/*
 .bin
+out
 
 # Avoid ignoring Gradle wrapper jar file, Gradle wrappper properties
 !gradle-wrapper.jar

--- a/.gitignore
+++ b/.gitignore
@@ -61,3 +61,5 @@ gradle-app.setting
 **/*.lock
 **/*.bin.gradle/**/*.lock
 .gradle/**/*.bin
+
+src/main/generated/

--- a/src/main/java/com/airbng/common/response/status/BaseResponseStatus.java
+++ b/src/main/java/com/airbng/common/response/status/BaseResponseStatus.java
@@ -32,7 +32,7 @@ public enum BaseResponseStatus implements ResponseStatus{
     INVALID_MEMBER(2007, HttpStatus.UNAUTHORIZED.value(), "유효하지 않은 멤버입니다."),
     NOT_UPDATE_MEMBER(2008, HttpStatus.NO_CONTENT.value(), "멤버 정보가 변경되지 않았습니다."),
     SUCCESS_LOGOUT(2000, HttpStatus.OK.value(), "로그아웃에 성공하였습니다."),
-
+    FAILED_UPDATE_MEMBER(2009, HttpStatus.UNAUTHORIZED.value(), "정보가 올바르지 않아 수정에 실패하였습니다."),
     /**
      * 3000 락커 관련 코드
      */

--- a/src/main/java/com/airbng/controller/MemberController.java
+++ b/src/main/java/com/airbng/controller/MemberController.java
@@ -15,6 +15,7 @@ import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
+
 import static com.airbng.common.response.status.BaseResponseStatus.SUCCESS_LOGIN;
 import static com.airbng.common.response.status.BaseResponseStatus.SUCCESS_LOGOUT;
 
@@ -61,16 +62,13 @@ public class MemberController {
 
     @PostMapping("/my-page/update")
     public BaseResponse<MemberMyPageResponse> updateUserById(
-            @Valid @RequestPart ("memberUpdateRequest") MemberUpdateRequest memberUpdateRequest,
-            @RequestPart(value = "profileImage", required = false) MultipartFile profileImage,
-            HttpSession session) {
+            @Valid @RequestPart("memberUpdateRequest") MemberUpdateRequest memberUpdateRequest,
+            @RequestPart(value = "profileImage", required = false) MultipartFile profileImage) {
 
         log.info("회원 정보 수정 요청: {}", memberUpdateRequest);
         log.info("프로필 이미지: {}", profileImage != null ? profileImage.getOriginalFilename() : "없음");
 
         MemberMyPageResponse response = memberService.updateUserById(memberUpdateRequest, profileImage);
-        session.setAttribute("memberId", response.getMemberId());
-        session.setAttribute("nickname", response.getNickname());
         return new BaseResponse<>(response);
     }
 

--- a/src/main/java/com/airbng/controller/MemberController.java
+++ b/src/main/java/com/airbng/controller/MemberController.java
@@ -16,6 +16,7 @@ import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
+
 import static com.airbng.common.response.status.BaseResponseStatus.SUCCESS_LOGIN;
 import static com.airbng.common.response.status.BaseResponseStatus.SUCCESS_LOGOUT;
 
@@ -64,16 +65,13 @@ public class MemberController {
     @PostMapping("/my-page/update")
     @PreAuthorize("hasAnyAuthority('USER')")
     public BaseResponse<MemberMyPageResponse> updateUserById(
-            @Valid @RequestPart ("memberUpdateRequest") MemberUpdateRequest memberUpdateRequest,
-            @RequestPart(value = "profileImage", required = false) MultipartFile profileImage,
-            HttpSession session) {
+            @Valid @RequestPart("memberUpdateRequest") MemberUpdateRequest memberUpdateRequest,
+            @RequestPart(value = "profileImage", required = false) MultipartFile profileImage) {
 
         log.info("회원 정보 수정 요청: {}", memberUpdateRequest);
         log.info("프로필 이미지: {}", profileImage != null ? profileImage.getOriginalFilename() : "없음");
 
         MemberMyPageResponse response = memberService.updateUserById(memberUpdateRequest, profileImage);
-        session.setAttribute("memberId", response.getMemberId());
-        session.setAttribute("nickname", response.getNickname());
         return new BaseResponse<>(response);
     }
 }

--- a/src/main/java/com/airbng/controller/MemberController.java
+++ b/src/main/java/com/airbng/controller/MemberController.java
@@ -2,6 +2,7 @@ package com.airbng.controller;
 
 import com.airbng.common.response.BaseResponse;
 import com.airbng.dto.*;
+import com.airbng.security.domain.CustomUserDetails;
 import com.airbng.service.MemberService;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpSession;
@@ -12,6 +13,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.MediaType;
 import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
@@ -66,12 +68,13 @@ public class MemberController {
     @PreAuthorize("hasAnyAuthority('USER')")
     public BaseResponse<MemberMyPageResponse> updateUserById(
             @Valid @RequestPart("memberUpdateRequest") MemberUpdateRequest memberUpdateRequest,
-            @RequestPart(value = "profileImage", required = false) MultipartFile profileImage) {
+            @RequestPart(value = "profileImage", required = false) MultipartFile profileImage,
+            @AuthenticationPrincipal CustomUserDetails userDetails) {
 
         log.info("회원 정보 수정 요청: {}", memberUpdateRequest);
         log.info("프로필 이미지: {}", profileImage != null ? profileImage.getOriginalFilename() : "없음");
 
-        MemberMyPageResponse response = memberService.updateUserById(memberUpdateRequest, profileImage);
+        MemberMyPageResponse response = memberService.updateUserById(memberUpdateRequest, profileImage, userDetails);
         return new BaseResponse<>(response);
     }
 }

--- a/src/main/java/com/airbng/domain/Member.java
+++ b/src/main/java/com/airbng/domain/Member.java
@@ -54,6 +54,14 @@ public class Member extends BaseTime {
     @OneToMany(mappedBy = "member")
     private Set<Zzim> zzims;
 
+    public void updateInfo(String email, String name, String phone, String nickname, Image profileImage) {
+        this.email = email;
+        this.name = name;
+        this.phone = phone;
+        this.nickname = nickname;
+        this.profileImage = profileImage;
+    }
+
     //   테스트용
     public static Member withId(Long memberId) {
         return Member.builder()

--- a/src/main/java/com/airbng/domain/Member.java
+++ b/src/main/java/com/airbng/domain/Member.java
@@ -60,6 +60,14 @@ public class Member extends BaseTime {
     @OneToMany(mappedBy = "member")
     private Set<Zzim> zzims;
 
+    public void updateInfo(String email, String name, String phone, String nickname, Image profileImage) {
+        this.email = email;
+        this.name = name;
+        this.phone = phone;
+        this.nickname = nickname;
+        this.profileImage = profileImage;
+    }
+
     //   테스트용
     public static Member withId(Long memberId) {
         return Member.builder()

--- a/src/main/java/com/airbng/domain/image/Image.java
+++ b/src/main/java/com/airbng/domain/image/Image.java
@@ -22,15 +22,15 @@ public class Image extends BaseTime {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long imageId;
 
-    @Column(nullable = false)
+    @Column(nullable = false, columnDefinition = "VARCHAR(1000)")
     private String url;
 
     @Column(nullable = false)
     private String uploadName;
 
     @Enumerated(EnumType.STRING)
-    @Column(nullable = false, columnDefinition = "VARCHAR(10)")
-    private BaseStatus status;
+    @Column(nullable = false, columnDefinition = "VARCHAR(10) DEFAULT 'ACTIVE'" )
+    private BaseStatus status = BaseStatus.ACTIVE;
 
     // com.airbng.domain.image.Image
     public static Image withId(Long imageId) {
@@ -38,6 +38,7 @@ public class Image extends BaseTime {
                 .imageId(imageId)
                 .url("https://example.com/images/profile" + imageId + ".jpg")
                 .uploadName("profile" + imageId + ".jpg")
+                .status(BaseStatus.ACTIVE)
                 .build();
     }
 

--- a/src/main/java/com/airbng/dto/MemberMyPageResponse.java
+++ b/src/main/java/com/airbng/dto/MemberMyPageResponse.java
@@ -1,10 +1,8 @@
 package com.airbng.dto;
 
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
-import lombok.Builder;
+import com.airbng.domain.Member;
+import jakarta.validation.constraints.Min;
+import lombok.*;
 
 
 @Getter
@@ -20,4 +18,17 @@ public class MemberMyPageResponse {
     private String nickname;
     private Long profileImageId;
     private String url;
+
+
+    public static MemberMyPageResponse from(Member member) {
+        return MemberMyPageResponse.builder()
+                .memberId(member.getMemberId())
+                .email(member.getEmail())
+                .name(member.getName())
+                .phone(member.getPhone())
+                .nickname(member.getNickname())
+                .profileImageId(member.getProfileImage() != null ? member.getProfileImage().getImageId() : null)
+                .url(member.getProfileImage() != null ? member.getProfileImage().getUrl() : null)
+                .build();
+    }
 }

--- a/src/main/java/com/airbng/repository/MemberRepository.java
+++ b/src/main/java/com/airbng/repository/MemberRepository.java
@@ -6,5 +6,11 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
 
+    boolean existsByEmail(String email);
+
+    boolean existsByNickname(String nickname);
+
+    boolean existsByPhone(String phone);
+
     boolean existsByMemberId(Long memberId);
 }

--- a/src/main/java/com/airbng/repository/MemberRepository.java
+++ b/src/main/java/com/airbng/repository/MemberRepository.java
@@ -17,12 +17,6 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
 
     boolean existsByMemberId(Long memberId);
 
-    boolean existsByNickname(String nickname);
-
-    boolean existsByEmail(String email);
-
-    boolean existsByPhone(String phone);
-
     Member findMemberByEmail(String email);
 
     Optional<Member> findByEmail(String email);

--- a/src/main/java/com/airbng/repository/MemberRepository.java
+++ b/src/main/java/com/airbng/repository/MemberRepository.java
@@ -9,6 +9,12 @@ import java.util.Optional;
 @Repository
 public interface MemberRepository extends JpaRepository<Member, Long> {
 
+    boolean existsByEmail(String email);
+
+    boolean existsByNickname(String nickname);
+
+    boolean existsByPhone(String phone);
+
     boolean existsByMemberId(Long memberId);
 
     boolean existsByNickname(String nickname);

--- a/src/main/java/com/airbng/service/ImageService.java
+++ b/src/main/java/com/airbng/service/ImageService.java
@@ -3,8 +3,9 @@ package com.airbng.service;
 import com.airbng.domain.image.Image;
 import org.springframework.web.multipart.MultipartFile;
 
+
 public interface ImageService {
     Image uploadProfileImage(MultipartFile file);
     Image getDefaultProfileImage();
-    Image updateDefaultProfileImage(MultipartFile file, Long memberId);
+    Image updateProfileImage(MultipartFile file, Long memberId);
 }

--- a/src/main/java/com/airbng/service/ImageServiceImpl.java
+++ b/src/main/java/com/airbng/service/ImageServiceImpl.java
@@ -1,54 +1,46 @@
 package com.airbng.service;
 
-import com.airbng.common.exception.ImageException;
+import com.airbng.common.exception.MemberException;
+import com.airbng.domain.Member;
 import com.airbng.domain.base.BaseStatus;
 import com.airbng.domain.image.Image;
-import com.airbng.mappers.ImageMapper;
 import com.airbng.repository.ImageRepository;
+import com.airbng.repository.MemberRepository;
 import com.airbng.util.S3Utils;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
-import java.io.IOException;
-import java.util.UUID;
+import static com.airbng.common.response.status.BaseResponseStatus.NOT_FOUND_MEMBER;
 
-import static com.airbng.common.response.status.BaseResponseStatus.UPLOAD_FAILED;
 
 @Service
 @RequiredArgsConstructor
+@Transactional
+@Slf4j
 public class ImageServiceImpl implements ImageService {
     private final ImageRepository imageRepository;
-    private final ImageMapper imageMapper;
     private final S3Utils s3Utils;
+    private final MemberRepository memberRepository;
+
 
     @Value("${image.default-url}")
     private String defaultImageUrl;
 
     @Override
     public Image uploadProfileImage(MultipartFile file) {
-
-        String uuid = UUID.randomUUID().toString();
-        String fileName = uuid + "_" + file.getOriginalFilename();
-        String path = "profiles/" + fileName;
-
-        String url = null;
-        try {
-            url = s3Utils.upload(file, path);
-        } catch (IOException e) {
-            throw new ImageException(UPLOAD_FAILED);
-        }
+        s3Utils.createFileName(file.getOriginalFilename());
 
         Image image = Image.builder()
-                .url(url)
+                .url(s3Utils.upload(file))
                 .uploadName(file.getOriginalFilename())
                 .status(BaseStatus.ACTIVE)
                 .build();
 
-        imageRepository.save(image);
-        return image;
+        return imageRepository.save(image);
     }
 
     public Image getDefaultProfileImage() {
@@ -61,10 +53,21 @@ public class ImageServiceImpl implements ImageService {
         return image;
     }
 
-    public Image updateDefaultProfileImage(MultipartFile file, Long memberId) {
-        if (file != null && !file.isEmpty()) {
-            return this.uploadProfileImage(file);
+    @Transactional
+    public Image updateProfileImage(MultipartFile file, Long memberId) {
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new MemberException(NOT_FOUND_MEMBER));
+
+        Image image = member.getProfileImage();
+
+        if (!image.getUploadName().equals("default.jpg")) {
+            s3Utils.delete(image.getUrl());
         }
-        return imageMapper.findImageIdByMemberId(memberId); // 기존 이미지 유지
+
+        String newUrl = s3Utils.upload(file);
+        image.setUrl(newUrl);
+        image.setUploadName(file.getOriginalFilename());
+
+        return image;
     }
 }

--- a/src/main/java/com/airbng/service/LockerServiceImpl.java
+++ b/src/main/java/com/airbng/service/LockerServiceImpl.java
@@ -137,22 +137,11 @@ public class LockerServiceImpl implements LockerService {
                     throw new ImageException(EMPTY_FILE);
                 }
 
-                // 1. 파일명 + 경로 지정
-                String uuid = UUID.randomUUID().toString();
-                String fileName = uuid + "_" + file.getOriginalFilename();
-                String path = "lockers/" + fileName;
+                s3Utils.createFileName(file.getOriginalFilename());
 
-                // 2. 업로드 및 예외 처리
-                String imageUrl;
-                try {
-                    imageUrl = s3Utils.upload(file, path); // 확장자 검사 포함됨
-                } catch (IOException e) {
-                    throw new ImageException(UPLOAD_FAILED); // 필요 시 추가 정의
-                }
-
-                // 3. DB 저장
+//                 3. DB 저장
                 Image image = Image.builder()
-                        .url(imageUrl)
+                        .url(s3Utils.upload(file))
                         .uploadName(file.getOriginalFilename())
                         .build();
 
@@ -268,7 +257,7 @@ public class LockerServiceImpl implements LockerService {
                 String uuid = UUID.randomUUID().toString();
                 String fileName = uuid + "_" + file.getOriginalFilename();
                 String path = "lockers/" + fileName;
-                String url = s3Utils.upload(file, path);
+                String url = s3Utils.upload(file);
 
                 Image image = Image.builder()
                         .url(url)

--- a/src/main/java/com/airbng/service/MemberService.java
+++ b/src/main/java/com/airbng/service/MemberService.java
@@ -2,12 +2,13 @@ package com.airbng.service;
 
 import com.airbng.dto.*;
 import com.airbng.domain.Member;
+import com.airbng.security.domain.CustomUserDetails;
 import org.springframework.web.multipart.MultipartFile;
 
 public interface MemberService {
     void signup(MemberSignupRequest dto, MultipartFile profileImage);
     void emailCheck(String email);
     MemberMyPageResponse findUserById(Long memberId);
-    MemberMyPageResponse updateUserById(MemberUpdateRequest memberUpdateRequest, MultipartFile profileImage);
+    MemberMyPageResponse updateUserById(MemberUpdateRequest memberUpdateRequest, MultipartFile profileImage, CustomUserDetails userDetails);
     void nicknameCheck(String nickname);
 }

--- a/src/main/java/com/airbng/service/MemberServiceImpl.java
+++ b/src/main/java/com/airbng/service/MemberServiceImpl.java
@@ -94,16 +94,16 @@ public class MemberServiceImpl implements MemberService {
 
         if (!userId.equals(request.getMemberId())) {
             throw new MemberException(FAILED_UPDATE_MEMBER);
-        } else {
-            // 닉네임 중복 체크
-            if (memberRepository.existsByNickname(request.getNickname())) {
-                throw new MemberException(DUPLICATE_NICKNAME);
-            }
-
-            // 휴대폰 중복 체크
-            if (memberRepository.existsByPhone(request.getPhone())) {
-                throw new MemberException(DUPLICATE_PHONE);
-            }
+        }
+        // 닉네임 중복 체크
+        if (!member.getNickname().equals(request.getNickname()) &&
+                memberRepository.existsByNickname(request.getNickname())) {
+            throw new MemberException(DUPLICATE_NICKNAME);
+        }
+        // 휴대폰 중복 체크
+        if (member.getPhone().equals(request.getPhone()) &&
+                memberRepository.existsByPhone(request.getPhone())) {
+            throw new MemberException(DUPLICATE_PHONE);
         }
 
         Image image;

--- a/src/main/java/com/airbng/service/MemberServiceImpl.java
+++ b/src/main/java/com/airbng/service/MemberServiceImpl.java
@@ -90,15 +90,6 @@ public class MemberServiceImpl implements MemberService {
         Member member = memberRepository.findById(request.getMemberId())
                 .orElseThrow(() -> new MemberException(NOT_FOUND_MEMBER));
 
-        // 이메일 검증 및 중복 체크 (기존 이메일과 다른 경우에만)
-        if (!emailValidator.isValidEmail(request.getEmail())) {
-            throw new MemberException(INVALID_EMAIL);
-        }
-        if (!member.getMemberId().equals(request.getMemberId()) &&
-                memberRepository.existsByEmail(request.getEmail())) {
-            throw new MemberException(DUPLICATE_EMAIL);
-        }
-
         // 닉네임 중복 체크
         if(!member.getMemberId().equals(request.getMemberId()) &&
                 memberRepository.existsByNickname(request.getNickname())) {
@@ -120,7 +111,7 @@ public class MemberServiceImpl implements MemberService {
                     : imageService.getDefaultProfileImage();
         }
 
-        member.updateInfo(request.getEmail(), request.getName(), request.getPhone(), request.getNickname(), image);
+        member.updateInfo(member.getEmail(), request.getName(), request.getPhone(), request.getNickname(), image);
         return MemberMyPageResponse.from(member);
     }
 }

--- a/src/main/java/com/airbng/service/MemberServiceImpl.java
+++ b/src/main/java/com/airbng/service/MemberServiceImpl.java
@@ -24,6 +24,7 @@ import static com.airbng.common.response.status.BaseResponseStatus.*;
 @Service
 @RequiredArgsConstructor
 @Slf4j
+@Transactional(readOnly = true)
 public class MemberServiceImpl implements MemberService {
 
     private final MemberMapper memberMapper;
@@ -76,64 +77,38 @@ public class MemberServiceImpl implements MemberService {
         if (memberRepository.existsByNickname(nickname)) throw new MemberException(DUPLICATE_NICKNAME);
     }
 
-
     @Override
     public MemberMyPageResponse findUserById(Long memberId) {
-        //Long memberId = request.getMemberId();
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new MemberException(NOT_FOUND_MEMBER));
 
-        MemberMyPageResponse response = memberMapper.findUserById(memberId);
-
-        if (response == null) throw new MemberException(NOT_FOUND_MEMBER);
-
-        return  MemberMyPageResponse.builder()
-                .memberId(response.getMemberId())
-                .email(response.getEmail())
-                .name(response.getName())
-                .phone(response.getPhone())
-                .nickname(response.getNickname())
-                .profileImageId(response.getProfileImageId())
-                .url(response.getUrl())
-                .build();
-
+        return MemberMyPageResponse.from(member);
     }
 
     @Transactional
     @Override
     public MemberMyPageResponse updateUserById(MemberUpdateRequest request, MultipartFile profileImage) {
-        MemberMyPageResponse existing = memberMapper.findUserById(request.getMemberId());
-
-        // 기존 값이 null이면 현재 값으로 설정
-        if (request.getEmail() == null || request.getEmail().isEmpty()) {
-            request.setEmail(existing.getEmail());
-        }
-        if (request.getName() == null || request.getName().isEmpty()) {
-            request.setName(existing.getName());
-        }
-        if (request.getPhone() == null || request.getPhone().isEmpty()) {
-            request.setPhone(existing.getPhone());
-        }
-        if (request.getNickname() == null || request.getNickname().isEmpty()) {
-            request.setNickname(existing.getNickname());
-        }
+        Member member = memberRepository.findById(request.getMemberId())
+                .orElseThrow(() -> new MemberException(NOT_FOUND_MEMBER));
 
         // 이메일 검증 및 중복 체크 (기존 이메일과 다른 경우에만)
         if (!emailValidator.isValidEmail(request.getEmail())) {
             throw new MemberException(INVALID_EMAIL);
         }
-        if (!request.getEmail().equals(existing.getEmail()) &&
-                memberMapper.findByEmail(request.getEmail())) {
+        if (!member.getMemberId().equals(request.getMemberId()) &&
+                memberRepository.existsByEmail(request.getEmail())) {
             throw new MemberException(DUPLICATE_EMAIL);
         }
 
-        // 닉네임 중복 체크 (기존 닉네임과 다른 경우에만)
-        if (!request.getNickname().equals(existing.getNickname()) &&
-                memberMapper.findByNickname(request.getNickname())) {
+        // 닉네임 중복 체크
+        if(!member.getMemberId().equals(request.getMemberId()) &&
+                memberRepository.existsByNickname(request.getNickname())) {
             throw new MemberException(DUPLICATE_NICKNAME);
         }
 
-        // 전화번호 중복 체크 (기존 전화번호와 다른 경우에만)
-        if (!request.getPhone().equals(existing.getPhone()) &&
-                memberMapper.findByPhone(request.getPhone())) {
+        // 휴대폰 중복 체크
+        if(!member.getMemberId().equals(request.getMemberId()) &&
+                memberRepository.existsByPhone(request.getPhone())) {
             throw new MemberException(DUPLICATE_PHONE);
         }
 
@@ -141,12 +116,8 @@ public class MemberServiceImpl implements MemberService {
                 ? imageService.uploadProfileImage(profileImage)
                 : imageService.updateDefaultProfileImage(profileImage, request.getMemberId());
 
-        request.setProfileImageId(image.getImageId());
+        member.updateInfo(request.getEmail(), request.getName(), request.getPhone(), request.getNickname(), image);
 
-        int updateCount = memberMapper.updateUserById(request);
-
-        if (updateCount == 0) throw new MemberException(NOT_UPDATE_MEMBER);
-
-        return memberMapper.findUserById(request.getMemberId());
+        return MemberMyPageResponse.from(member);
     }
 }

--- a/src/main/java/com/airbng/service/MemberServiceImpl.java
+++ b/src/main/java/com/airbng/service/MemberServiceImpl.java
@@ -7,6 +7,7 @@ import com.airbng.domain.image.Image;
 import com.airbng.dto.*;
 import com.airbng.mappers.ImageMapper;
 import com.airbng.mappers.MemberMapper;
+import com.airbng.repository.MemberRepository;
 import com.airbng.validator.EmailValidator;
 import com.airbng.validator.PasswordValidator;
 import lombok.RequiredArgsConstructor;
@@ -22,6 +23,7 @@ import static com.airbng.common.response.status.BaseResponseStatus.*;
 @Service
 @RequiredArgsConstructor
 @Slf4j
+@Transactional(readOnly = true)
 public class MemberServiceImpl implements MemberService {
 
     private final MemberMapper memberMapper;
@@ -30,6 +32,7 @@ public class MemberServiceImpl implements MemberService {
     private final BCryptPasswordEncoder passwordEncoder;
     private final EmailValidator emailValidator;
     private final PasswordValidator passwordValidator;
+    private final MemberRepository memberRepository;
 
     @Transactional
     @Override
@@ -91,64 +94,38 @@ public class MemberServiceImpl implements MemberService {
         if (memberMapper.findByNickname(nickname))          throw new MemberException(DUPLICATE_NICKNAME);
     }
 
-
     @Override
     public MemberMyPageResponse findUserById(Long memberId) {
-        //Long memberId = request.getMemberId();
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new MemberException(NOT_FOUND_MEMBER));
 
-        MemberMyPageResponse response = memberMapper.findUserById(memberId);
-
-        if (response == null) throw new MemberException(NOT_FOUND_MEMBER);
-
-        return  MemberMyPageResponse.builder()
-                .memberId(response.getMemberId())
-                .email(response.getEmail())
-                .name(response.getName())
-                .phone(response.getPhone())
-                .nickname(response.getNickname())
-                .profileImageId(response.getProfileImageId())
-                .url(response.getUrl())
-                .build();
-
+        return MemberMyPageResponse.from(member);
     }
 
     @Transactional
     @Override
     public MemberMyPageResponse updateUserById(MemberUpdateRequest request, MultipartFile profileImage) {
-        MemberMyPageResponse existing = memberMapper.findUserById(request.getMemberId());
-
-        // 기존 값이 null이면 현재 값으로 설정
-        if (request.getEmail() == null || request.getEmail().isEmpty()) {
-            request.setEmail(existing.getEmail());
-        }
-        if (request.getName() == null || request.getName().isEmpty()) {
-            request.setName(existing.getName());
-        }
-        if (request.getPhone() == null || request.getPhone().isEmpty()) {
-            request.setPhone(existing.getPhone());
-        }
-        if (request.getNickname() == null || request.getNickname().isEmpty()) {
-            request.setNickname(existing.getNickname());
-        }
+        Member member = memberRepository.findById(request.getMemberId())
+                .orElseThrow(() -> new MemberException(NOT_FOUND_MEMBER));
 
         // 이메일 검증 및 중복 체크 (기존 이메일과 다른 경우에만)
         if (!emailValidator.isValidEmail(request.getEmail())) {
             throw new MemberException(INVALID_EMAIL);
         }
-        if (!request.getEmail().equals(existing.getEmail()) &&
-                memberMapper.findByEmail(request.getEmail())) {
+        if (!member.getMemberId().equals(request.getMemberId()) &&
+                memberRepository.existsByEmail(request.getEmail())) {
             throw new MemberException(DUPLICATE_EMAIL);
         }
 
-        // 닉네임 중복 체크 (기존 닉네임과 다른 경우에만)
-        if (!request.getNickname().equals(existing.getNickname()) &&
-                memberMapper.findByNickname(request.getNickname())) {
+        // 닉네임 중복 체크
+        if(!member.getMemberId().equals(request.getMemberId()) &&
+                memberRepository.existsByNickname(request.getNickname())) {
             throw new MemberException(DUPLICATE_NICKNAME);
         }
 
-        // 전화번호 중복 체크 (기존 전화번호와 다른 경우에만)
-        if (!request.getPhone().equals(existing.getPhone()) &&
-                memberMapper.findByPhone(request.getPhone())) {
+        // 휴대폰 중복 체크
+        if(!member.getMemberId().equals(request.getMemberId()) &&
+                memberRepository.existsByPhone(request.getPhone())) {
             throw new MemberException(DUPLICATE_PHONE);
         }
 
@@ -156,12 +133,8 @@ public class MemberServiceImpl implements MemberService {
                 ? imageService.uploadProfileImage(profileImage)
                 : imageService.updateDefaultProfileImage(profileImage, request.getMemberId());
 
-        request.setProfileImageId(image.getImageId());
+        member.updateInfo(request.getEmail(), request.getName(), request.getPhone(), request.getNickname(), image);
 
-        int updateCount = memberMapper.updateUserById(request);
-
-        if (updateCount == 0) throw new MemberException(NOT_UPDATE_MEMBER);
-
-        return memberMapper.findUserById(request.getMemberId());
+        return MemberMyPageResponse.from(member);
     }
 }

--- a/src/main/java/com/airbng/service/MemberServiceImpl.java
+++ b/src/main/java/com/airbng/service/MemberServiceImpl.java
@@ -10,6 +10,7 @@ import com.airbng.dto.MemberSignupRequest;
 import com.airbng.dto.MemberUpdateRequest;
 import com.airbng.mappers.MemberMapper;
 import com.airbng.repository.MemberRepository;
+import com.airbng.security.domain.CustomUserDetails;
 import com.airbng.validator.EmailValidator;
 import com.airbng.validator.PasswordValidator;
 import lombok.RequiredArgsConstructor;
@@ -86,25 +87,28 @@ public class MemberServiceImpl implements MemberService {
 
     @Transactional
     @Override
-    public MemberMyPageResponse updateUserById(MemberUpdateRequest request, MultipartFile profileImage) {
-        Member member = memberRepository.findById(request.getMemberId())
+    public MemberMyPageResponse updateUserById(MemberUpdateRequest request, MultipartFile profileImage, CustomUserDetails userDetails) {
+        Long userId = userDetails.getId();
+        Member member = memberRepository.findById(userId)
                 .orElseThrow(() -> new MemberException(NOT_FOUND_MEMBER));
 
-        // 닉네임 중복 체크
-        if(!member.getMemberId().equals(request.getMemberId()) &&
-                memberRepository.existsByNickname(request.getNickname())) {
-            throw new MemberException(DUPLICATE_NICKNAME);
-        }
+        if (!userId.equals(request.getMemberId())) {
+            throw new MemberException(FAILED_UPDATE_MEMBER);
+        } else {
+            // 닉네임 중복 체크
+            if (memberRepository.existsByNickname(request.getNickname())) {
+                throw new MemberException(DUPLICATE_NICKNAME);
+            }
 
-        // 휴대폰 중복 체크
-        if(!member.getMemberId().equals(request.getMemberId()) &&
-                memberRepository.existsByPhone(request.getPhone())) {
-            throw new MemberException(DUPLICATE_PHONE);
+            // 휴대폰 중복 체크
+            if (memberRepository.existsByPhone(request.getPhone())) {
+                throw new MemberException(DUPLICATE_PHONE);
+            }
         }
 
         Image image;
         if (profileImage != null && !profileImage.isEmpty()) {
-            image = imageService.updateProfileImage(profileImage, member.getMemberId());
+            image = imageService.updateProfileImage(profileImage, userId);
         } else {
             image = (member.getProfileImage() != null)
                     ? member.getProfileImage()

--- a/src/main/java/com/airbng/service/MemberServiceImpl.java
+++ b/src/main/java/com/airbng/service/MemberServiceImpl.java
@@ -95,14 +95,17 @@ public class MemberServiceImpl implements MemberService {
         if (!userId.equals(request.getMemberId())) {
             throw new MemberException(FAILED_UPDATE_MEMBER);
         }
+
+        String phone = request.getPhone().replace("-", "");
+
         // 닉네임 중복 체크
         if (!member.getNickname().equals(request.getNickname()) &&
                 memberRepository.existsByNickname(request.getNickname())) {
             throw new MemberException(DUPLICATE_NICKNAME);
         }
         // 휴대폰 중복 체크
-        if (member.getPhone().equals(request.getPhone()) &&
-                memberRepository.existsByPhone(request.getPhone())) {
+        if (!member.getPhone().equals(phone) &&
+                memberRepository.existsByPhone(phone)) {
             throw new MemberException(DUPLICATE_PHONE);
         }
 

--- a/src/main/java/com/airbng/service/MemberServiceImpl.java
+++ b/src/main/java/com/airbng/service/MemberServiceImpl.java
@@ -72,7 +72,6 @@ public class MemberServiceImpl implements MemberService {
         if (!emailValidator.isValidEmail(email))           throw new MemberException(INVALID_EMAIL);
     }
 
-
     public void nicknameCheck(String nickname) {
         if (memberRepository.existsByNickname(nickname)) throw new MemberException(DUPLICATE_NICKNAME);
     }
@@ -112,12 +111,16 @@ public class MemberServiceImpl implements MemberService {
             throw new MemberException(DUPLICATE_PHONE);
         }
 
-        Image image = (profileImage != null && !profileImage.isEmpty())
-                ? imageService.uploadProfileImage(profileImage)
-                : imageService.updateDefaultProfileImage(profileImage, request.getMemberId());
+        Image image;
+        if (profileImage != null && !profileImage.isEmpty()) {
+            image = imageService.updateProfileImage(profileImage, member.getMemberId());
+        } else {
+            image = (member.getProfileImage() != null)
+                    ? member.getProfileImage()
+                    : imageService.getDefaultProfileImage();
+        }
 
         member.updateInfo(request.getEmail(), request.getName(), request.getPhone(), request.getNickname(), image);
-
         return MemberMyPageResponse.from(member);
     }
 }

--- a/src/main/java/com/airbng/util/S3Utils.java
+++ b/src/main/java/com/airbng/util/S3Utils.java
@@ -2,20 +2,28 @@ package com.airbng.util;
 
 import com.airbng.common.exception.ImageException;
 import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.model.DeleteObjectRequest;
 import com.amazonaws.services.s3.model.ObjectMetadata;
 import com.amazonaws.services.s3.model.PutObjectRequest;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;
+import java.io.InputStream;
+import java.net.URLDecoder;
 import java.util.List;
+import java.util.UUID;
 
 import static com.airbng.common.response.status.BaseResponseStatus.INVALID_EXTENSIONS;
+import static com.airbng.common.response.status.BaseResponseStatus.UPLOAD_FAILED;
+
 
 @Component
 @RequiredArgsConstructor
+@Slf4j
 public class S3Utils {
 
     private final AmazonS3Client amazonS3Client;
@@ -24,18 +32,23 @@ public class S3Utils {
     @Value("${cloud.aws.s3.bucket}")
     private String bucket;
 
-    public String upload(MultipartFile file, String filePath) throws IOException {
-        validateFileExtension(file); // 확장자 검사 추가
+    public String upload(MultipartFile file) {
 
+        String fileName = createFileName(file.getOriginalFilename());
         ObjectMetadata metadata = new ObjectMetadata();
         metadata.setContentLength(file.getSize());
         metadata.setContentType(file.getContentType());
 
-        amazonS3Client.putObject(
-                new PutObjectRequest(bucket, filePath, file.getInputStream(), metadata)
-        );
+        validateFileExtension(file); // 확장자 검사 추가
 
-        return amazonS3Client.getUrl(bucket, filePath).toString();
+
+        try (InputStream inputStream = file.getInputStream()) {
+            amazonS3Client.putObject (new PutObjectRequest(bucket, fileName, inputStream, metadata));
+        } catch (IOException e) {
+            throw new ImageException(UPLOAD_FAILED);
+        }
+
+        return amazonS3Client.getUrl(bucket, fileName).toString();
     }
 
     private void validateFileExtension(MultipartFile file) {
@@ -48,5 +61,31 @@ public class S3Utils {
         if (!ALLOWED_EXTENSIONS.contains(extension)) {
             throw new ImageException(INVALID_EXTENSIONS);
         }
+    }
+
+    public void delete(String imageUrl) {
+        log.info("Deleting image from S3. URL: {}", imageUrl);
+        String splitStr = ".com/";
+        String fileName = imageUrl.substring(imageUrl.lastIndexOf(splitStr) + splitStr.length());
+        String decodedFileName = URLDecoder.decode(fileName);
+
+        amazonS3Client.deleteObject(new DeleteObjectRequest(bucket, decodedFileName));
+
+        // 삭제가 됐다면
+        if (fileName == null || fileName.isEmpty()) {
+            log.warn("Image URL is null or empty, skipping deletion");
+            return;
+        } else {
+            log.info("Attempting to delete S3 object with key: {}", fileName);
+        }
+    }
+
+    public String createFileName(String fileName) {
+        String uuid = UUID.randomUUID().toString();
+
+        String newFileName = uuid + "_" + fileName;
+        String path = "profiles/" + newFileName;
+
+        return path;
     }
 }


### PR DESCRIPTION
## 요약 (Summary)
- 회원정보 조회, 수정 -> JPA로 변환

## 🔑 변경 사항 (Key Changes)
- 조회(`findUserById`) 
- 수정(`updateUserById`)

## 📝 리뷰 요구사항 (To Reviewers)
- [ ] 회원정보가 정상적으로 조회되는지 확인
- [ ] 회원정보가 정상적으로 수정되는지 확인
- [ ] 회원정보 수정 시 이미지 업로드 정상 동작 확인 (주의: AWS 비용 문제로 다량 업로드는 지양)
- [ ] 회원정보 수정 시 중복 검증 로직 정상 동작 확인

## 확인 방법 
- postman으로 확인해주세요!
- key : `memberUpdateRequest`, `profileImage`
```
{
  "memberId": 1,
  "email": "keeper128@gmalio.com",
  "name": "하하",
  "phone": "01000000000",
  "nickname": "123",
  "profileImageId": 1
}
{
  "memberId": 1,
  "email": "keeper128@gmalio.com",
  "name": "하하",
  "phone": "01012344567",
  "nickname": "123",
  "profileImageId": 1
}
```
<img width="854" height="674" alt="스크린샷 2025-08-28 오후 4 25 12" src="https://github.com/user-attachments/assets/d1df89bb-6fec-4c57-a797-9f6ed87d288b" />
