### PR TITLE
[# 166] 보관소 심사 관련 도메인 추가

### DIFF
--- a/airbng-admin/src/main/java/com/airbng/admin/domain/LockerReview.java
+++ b/airbng-admin/src/main/java/com/airbng/admin/domain/LockerReview.java
@@ -1,0 +1,39 @@
+package com.airbng.admin.domain;
+
+import com.airbng.admin.domain.base.ReviewStatus;
+import com.airbng.common.base.BaseStatus;
+import com.airbng.common.base.BaseTime;
+import jakarta.persistence.*;
+import lombok.*;
+
+import static jakarta.persistence.FetchType.LAZY;
+
+@Getter
+@Setter
+@Entity
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class LockerReview extends BaseTime {
+
+        @Id
+        @GeneratedValue(strategy = GenerationType.IDENTITY)
+        private Long lockerReviewId;
+
+        @Enumerated(EnumType.STRING)
+        @Column(nullable = false)
+        private ReviewStatus reviewStatus;
+
+        @Column
+        private String reviewComment;
+
+        @OneToOne(fetch = LAZY)
+        @JoinColumn(name = "pending_locker_id", nullable = false)
+        private PendingLocker pendingLocker;
+
+        @Enumerated(EnumType.STRING)
+        @Column(nullable = false, columnDefinition = "VARCHAR(10)")
+        private BaseStatus status;
+
+}
+

--- a/airbng-admin/src/main/java/com/airbng/admin/domain/PendingLocker.java
+++ b/airbng-admin/src/main/java/com/airbng/admin/domain/PendingLocker.java
@@ -1,11 +1,63 @@
 package com.airbng.admin.domain;
 
+import com.airbng.admin.domain.base.LockerType;
+import com.airbng.common.base.BaseStatus;
 import com.airbng.common.base.BaseTime;
-import jakarta.persistence.Entity;
-import jakarta.persistence.Id;
+import jakarta.persistence.*;
+import lombok.*;
 
+import java.util.HashSet;
+import java.util.Set;
+
+@Getter
+@Setter
 @Entity
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
 public class PendingLocker extends BaseTime {
+
     @Id
-    private Long id;
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long pendingLockerId;
+
+    @Column(nullable = false)
+    private String lockerName;
+
+    @Column(nullable = false)
+    private String address;
+
+    @Column(nullable = false)
+    private String addressEnglish;
+
+    @Column(nullable = false)
+    private String addressDetail;
+
+    @Column(nullable = false)
+    private Double latitude;
+
+    @Column(nullable = false)
+    private Double longitude;
+
+    // TODO : 양방향 1:1 일 경우 fetch = LAZY 설정 적용 안되는듯?
+    @OneToOne(mappedBy = "pendingLocker", cascade = CascadeType.ALL)
+    private LockerReview lockerReview;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, columnDefinition = "VARCHAR(10)")
+    private BaseStatus status;
+
+    @OneToMany(mappedBy = "pendingLocker")
+    private Set<PendingLockerImage> pendingLockerImages;
+
+    @OneToMany(mappedBy = "pendingLocker")
+    @Builder.Default
+    private Set<PendingLockerJimtype> pendingLockerJimtypes = new HashSet<>();
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private LockerType lockerType;
+
+    @Column(nullable = false)
+    private Long memberId;
 }

--- a/airbng-admin/src/main/java/com/airbng/admin/domain/PendingLocker.java
+++ b/airbng-admin/src/main/java/com/airbng/admin/domain/PendingLocker.java
@@ -39,10 +39,6 @@ public class PendingLocker extends BaseTime {
     @Column(nullable = false)
     private Double longitude;
 
-    // TODO : 양방향 1:1 일 경우 fetch = LAZY 설정 적용 안되는듯?
-    @OneToOne(mappedBy = "pendingLocker", cascade = CascadeType.ALL)
-    private LockerReview lockerReview;
-
     @Enumerated(EnumType.STRING)
     @Column(nullable = false, columnDefinition = "VARCHAR(10)")
     private BaseStatus status;

--- a/airbng-admin/src/main/java/com/airbng/admin/domain/PendingLockerImage.java
+++ b/airbng-admin/src/main/java/com/airbng/admin/domain/PendingLockerImage.java
@@ -1,0 +1,33 @@
+package com.airbng.admin.domain;
+
+import com.airbng.common.base.BaseStatus;
+import com.airbng.common.base.BaseTime;
+import jakarta.persistence.*;
+import lombok.*;
+
+
+import static jakarta.persistence.FetchType.LAZY;
+
+@Getter
+@Setter
+@Entity
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class PendingLockerImage extends BaseTime {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long pendingLockerImageId;
+
+    @ManyToOne(fetch = LAZY)
+    @JoinColumn(name = "pending_locker_id", nullable = false)
+    private PendingLocker pendingLocker;
+
+    @Column(nullable = false)
+    private Long imageId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, columnDefinition = "VARCHAR(10)")
+    private BaseStatus status;
+}

--- a/airbng-admin/src/main/java/com/airbng/admin/domain/PendingLockerJimtype.java
+++ b/airbng-admin/src/main/java/com/airbng/admin/domain/PendingLockerJimtype.java
@@ -1,0 +1,31 @@
+package com.airbng.admin.domain;
+
+import com.airbng.common.base.BaseStatus;
+import com.airbng.common.base.BaseTime;
+import jakarta.persistence.*;
+import lombok.*;
+
+import static jakarta.persistence.FetchType.LAZY;
+
+@Getter
+@Setter
+@Entity
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class PendingLockerJimtype extends BaseTime {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long pendingLockerJimtypeId;
+
+    @ManyToOne(fetch = LAZY)
+    @JoinColumn(name = "pending_locker_id", nullable = false)
+    private PendingLocker pendingLocker;
+
+    @Column(nullable = false)
+    private Long jimtypeId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, columnDefinition = "VARCHAR(10)")
+    private BaseStatus status;
+}

--- a/airbng-admin/src/main/java/com/airbng/admin/domain/base/LockerType.java
+++ b/airbng-admin/src/main/java/com/airbng/admin/domain/base/LockerType.java
@@ -1,0 +1,6 @@
+package com.airbng.admin.domain.base;
+
+// 보관소 타입 (개인, 공공기관, 기업)
+public enum LockerType {
+    PERSONAL, PUBLIC, COMPANY;
+}

--- a/airbng-admin/src/main/java/com/airbng/admin/domain/base/ReviewStatus.java
+++ b/airbng-admin/src/main/java/com/airbng/admin/domain/base/ReviewStatus.java
@@ -1,0 +1,5 @@
+package com.airbng.admin.domain.base;
+
+public enum ReviewStatus {
+    WAITING, APPROVED, REJECTED;
+}


### PR DESCRIPTION
## 요약 (Summary)
- 보관소 심사 관련 도메인 작성

## 🔑 변경 사항 (Key Changes)
- `LockerType` enum 추가
  - `PERSONAL`, `PUBLIC`, `COMPANY`
- `ReviewStatus` enum 추가
  - `WAITING`, `APPROVED`, `REJECTED`
- `LockerReview` 심사 테이블 추가
- `PendingLocker` 심사 대상 락커 테이블 추가
- `PendingLockerImage` 심사 락커 이미지 테이블 추가
- `PendingLockerJimtype` 심사 락커 짐타입 테이블 추가

## 📝 리뷰 요구사항 (To Reviewers)
- [ ] `LockerType`과 `ReviewStatus` enum 네이밍이 적절한지 확인 부탁드립니다.
- [ ] 심사 대상 보관소 도메인 설계가 올바르게 작성되었는지 검토 부탁드립니다.