### PR TITLE
[#177] 만료된 토큰 예외처리 수정

### DIFF
--- a/airbng-platform/src/main/java/com/airbng/platform/common/response/status/BaseResponseStatus.java
+++ b/airbng-platform/src/main/java/com/airbng/platform/common/response/status/BaseResponseStatus.java
@@ -104,7 +104,7 @@ public enum BaseResponseStatus implements ResponseStatus{
     SESSION_EXPIRED(9004, HttpStatus.UNAUTHORIZED.value(), "세션이 만료되었습니다."),
 
     REFRESH_TOKEN_NOT_FOUND(9005, HttpStatus.BAD_REQUEST.value(), "리프레시 토큰이 존재하지 않습니다."),
-    EXPIRED_TOKEN(9006, HttpStatus.UNAUTHORIZED.value(), "리프레시 토큰이 만료되었습니다."),
+    EXPIRED_TOKEN(9006, HttpStatus.UNAUTHORIZED.value(), "토큰이 만료되었습니다."),
     INVALID_TOKEN(9007, HttpStatus.UNAUTHORIZED.value(),"유효하지 않는 토큰입니다."),
     INVALID_USERNAME_OR_PASSWORD(9008, HttpStatus.BAD_REQUEST.value(), "아이디 혹은 비밀번호가 올바르지 않습니다."),
     UNAUTHORIZED(9009, HttpStatus.UNAUTHORIZED.value(), "인증되지 않는 사용자입니다."),

--- a/airbng-platform/src/main/java/com/airbng/platform/config/SecurityConfig.java
+++ b/airbng-platform/src/main/java/com/airbng/platform/config/SecurityConfig.java
@@ -115,7 +115,7 @@ public class SecurityConfig {
 
     @Bean
     public JwtFilter jwtFilter() {
-        return new JwtFilter(jwtUtil);
+        return new JwtFilter(jwtUtil, customAuthenticationEntryPoint);
     }
 
     @Bean

--- a/airbng-platform/src/main/java/com/airbng/platform/security/filter/JwtFilter.java
+++ b/airbng-platform/src/main/java/com/airbng/platform/security/filter/JwtFilter.java
@@ -1,6 +1,7 @@
 package com.airbng.platform.security.filter;
 
 import com.airbng.platform.common.response.status.BaseResponseStatus;
+import com.airbng.platform.security.handler.CustomAuthenticationEntryPoint;
 import com.airbng.platform.security.util.JwtUtil;
 import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.MalformedJwtException;
@@ -13,6 +14,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.authentication.InsufficientAuthenticationException;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.UserDetails;
@@ -23,6 +25,7 @@ import java.io.IOException;
 import java.util.Map;
 import java.util.function.Function;
 
+import static com.airbng.platform.common.response.status.BaseResponseStatus.*;
 import static com.airbng.platform.security.util.JwtUtil.*;
 
 @Slf4j
@@ -31,6 +34,7 @@ import static com.airbng.platform.security.util.JwtUtil.*;
 public class JwtFilter extends OncePerRequestFilter {
 
     private final JwtUtil jwtUtil;
+    private final CustomAuthenticationEntryPoint customAuthenticationEntryPoint;
 
     @Override
     protected void doFilterInternal(HttpServletRequest request,
@@ -54,16 +58,16 @@ public class JwtFilter extends OncePerRequestFilter {
 
         } catch (MalformedJwtException e) {
             log.error("[JWT 필터] 토큰 검증 실패 : 잘못된 토큰 형식");
-            request.setAttribute("JWT_ERROR_CODE", BaseResponseStatus.INVALID_TOKEN);
-            throw new MalformedJwtException("잘못된 토큰 형식");
+            handleAuthError(request, response,INVALID_TOKEN, "invalid_token");
+            return;
         } catch (ExpiredJwtException e) {
             log.error("[JWT 필터] 토큰 검증 실패 : 만료된 토큰");
-            request.setAttribute("JWT_ERROR_CODE",  BaseResponseStatus.EXPIRED_TOKEN);
-            throw new ExpiredJwtException(null, null, "만료된 토큰");
+            handleAuthError(request,response, EXPIRED_TOKEN, "expired_token");
+            return;
         } catch (SignatureException e) {
             log.error("[JWT 필터] 토큰 검증 실패 : 잘못된 서명");
-            request.setAttribute("JWT_ERROR_CODE", BaseResponseStatus.INVALID_SIGNATURE);
-            throw new SignatureException("잘못된 서명");
+            handleAuthError(request,response, INVALID_SIGNATURE, "invalid_signature");
+            return;
         }
         filterChain.doFilter(request, response);
     }
@@ -95,6 +99,15 @@ public class JwtFilter extends OncePerRequestFilter {
         UserDetails userDetails = factory.apply(claims);
         SecurityContextHolder.getContext().setAuthentication(
             new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities())
+        );
+    }
+
+    private void handleAuthError(HttpServletRequest req, HttpServletResponse res,
+                                 BaseResponseStatus status, String reason) throws IOException, ServletException {
+        SecurityContextHolder.clearContext();
+        req.setAttribute("JWT_ERROR_STATUS", status);
+        customAuthenticationEntryPoint.commence(
+                req,res,new InsufficientAuthenticationException(reason)
         );
     }
 }


### PR DESCRIPTION
## 요약 (Summary)
- [x] 만료된 토큰의 경우 500 기본 서버 에러 응답에서 401 토큰 만료 응답으로 수정

## 🔑 변경 사항 (Key Changes)

- JwtFilter에서 CustomEntryPoint를 직접 호출 후 필터 체인 종료 -> EntryPoint는  CustomErrorResponder를 호출 하여 우리 응답 형식에 맞게 만료 응답
<img width="503" height="151" alt="image" src="https://github.com/user-attachments/assets/47681369-abd8-4018-94bc-916fe1f5232a" />


## 📝 리뷰 요구사항 (To Reviewers)

- [ ] 만료된 토큰의 경우 서버 오류가 아닌 만료 오류가 발생하는지 확인해주세요

## 확인 방법 
