### PR TITLE
[#185] 알림 한글 처리 수정

### DIFF
--- a/airbng-consumer/src/main/java/com/airbng/consumer/service/ReservationAlarmCacheServiceImpl.java
+++ b/airbng-consumer/src/main/java/com/airbng/consumer/service/ReservationAlarmCacheServiceImpl.java
@@ -80,8 +80,10 @@ public class ReservationAlarmCacheServiceImpl implements ReservationAlarmCacheSe
         return all.stream()
                 .map(s -> s.split("\\|", 2))          // [eventId, payload]
                 .filter(arr -> Long.parseLong(arr[0]) > lastId) // lastEventId 이후 것만 가져옴
-                .map(arr -> new AlarmPayloadResponse(Long.parseLong(arr[0]), arr[1]))                    // payload만 추출
-                .collect(Collectors.toList());
+                .map(arr -> new AlarmPayloadResponse(Long.parseLong(arr[0]), arr[1]))    // payload만 추출
+                .reduce((first, second) -> second)
+                .map(List::of)
+                .orElse(List.of());
     }
 
 

--- a/airbng-consumer/src/main/java/com/airbng/consumer/service/ReservationAlarmSseServiceImpl.java
+++ b/airbng-consumer/src/main/java/com/airbng/consumer/service/ReservationAlarmSseServiceImpl.java
@@ -2,6 +2,7 @@ package com.airbng.consumer.service;
 
 import com.airbng.consumer.dto.AlarmPayloadResponse;
 import com.airbng.consumer.auth.CustomUserDetails;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.MediaType;
@@ -28,6 +29,7 @@ public class ReservationAlarmSseServiceImpl implements ReservationAlarmSseServic
 
     // 알림 읽은 여부
     private final ReservationAlarmCacheService reservationAlarmCacheService;
+    private static final ObjectMapper objectMapper = new ObjectMapper();
 
     // 클라이언트와의 SSE 연결을 관리하기 위한 맵 (사용자가 여러개로 접속해도 sse연결 가능하도록 허용)
     //CopyOnWriteArrayList : 멀티스레드에 적합
@@ -69,7 +71,7 @@ public class ReservationAlarmSseServiceImpl implements ReservationAlarmSseServic
                     emitter.send(SseEmitter.event()
                             .id(alarm.getEventId().toString())
                             .name("alarm")
-                            .data(alarm.getData(), MediaType.APPLICATION_JSON));
+                            .data(objectMapper.writeValueAsString(alarm.getData()), MediaType.APPLICATION_JSON));
                 }
             }
 
@@ -97,7 +99,6 @@ public class ReservationAlarmSseServiceImpl implements ReservationAlarmSseServic
                 log.info("알림 전송 시도: memberId={}, data={}", memberId, payload);
 
                 List<SseEmitter> deadEmitters = new ArrayList<>();
-
                 for (SseEmitter emitter : emitters) {
                     try {
                         emitter.send(SseEmitter.event().id(eventId).name("alarm").data(payload, MediaType.APPLICATION_JSON));
@@ -105,6 +106,7 @@ public class ReservationAlarmSseServiceImpl implements ReservationAlarmSseServic
                         log.warn("SSE 메시지 전송 실패: memberId={}, error={}", memberId, e.getMessage());
                         deadEmitters.add(emitter);
                         emitter.completeWithError(e);
+                        removeEmitter(memberId, emitter);
                     }
                 }
                 // 연결 끊긴 emitter 정리

--- a/airbng-consumer/src/main/java/com/airbng/consumer/service/ReservationAlarmSseServiceImpl.java
+++ b/airbng-consumer/src/main/java/com/airbng/consumer/service/ReservationAlarmSseServiceImpl.java
@@ -29,7 +29,6 @@ public class ReservationAlarmSseServiceImpl implements ReservationAlarmSseServic
 
     // 알림 읽은 여부
     private final ReservationAlarmCacheService reservationAlarmCacheService;
-    private static final ObjectMapper objectMapper = new ObjectMapper();
 
     // 클라이언트와의 SSE 연결을 관리하기 위한 맵 (사용자가 여러개로 접속해도 sse연결 가능하도록 허용)
     //CopyOnWriteArrayList : 멀티스레드에 적합
@@ -60,18 +59,20 @@ public class ReservationAlarmSseServiceImpl implements ReservationAlarmSseServic
         });
 
         try {
-            emitter.send(SseEmitter.event().id("0").name("connect").data("SSE SUCCESS - memberId: " + memberId));
+            emitter.send(SseEmitter.event().name("connect").data("SSE SUCCESS - memberId: " + memberId));
 
             if (lastEventId != null) {
                 List<AlarmPayloadResponse> missedAlarms = reservationAlarmCacheService.getMissedAlarms(memberId, lastEventId);
+
                 for (AlarmPayloadResponse alarm : missedAlarms) {
+                    String json = new ObjectMapper().writeValueAsString(alarm.getData());
                     // Redis 시퀀스 ID 그대로 사용
                     log.info("놓친 알림 재전송: memberId={}, eventId={}, data={}", memberId, alarm.getEventId().toString(), alarm.getData());
                     // 놓친 알림 재전송
                     emitter.send(SseEmitter.event()
                             .id(alarm.getEventId().toString())
                             .name("alarm")
-                            .data(objectMapper.writeValueAsString(alarm.getData()), MediaType.APPLICATION_JSON));
+                            .data(json.getBytes("UTF-8"), MediaType.valueOf("text/event-stream;charset=UTF-8")));
                 }
             }
 


### PR DESCRIPTION
## 요약 (Summary)
- [x] 한글 깨짐 및 놓친 알림 여러번 오는 오류 수정

## 🔑 변경 사항 (Key Changes)

- ReservationAlarmSseServiceImpl 에서 놓친 알림 전송 부분 ObjectMapper 사용해서 JSON 문자열로 변환 후,
.getBytes("UTF-8")로 인코딩
- ReservationAlarmCacheServiceImpl 에서 놓친 최신 알림만 가져오게 수정

## 📝 리뷰 요구사항 (To Reviewers)

- [ ] 알림이 제대로 오는지 확인 부탁드립니다. 

## 확인 방법 
!!! 레디스에 있는 alarm과 alarms 관련 모든 값 지우고 시작 -> KEY "alarm*" /  KEY "alarms*"로 확인 후 모든 값 삭제 (DEL 키값)

!!! 해당 insert문 넣고 실행

```
INSERT INTO reservation (
    created_at, dropper_id, end_time, keeper_id, locker_id, payment_id, reservation_id, start_time, updated_at, state, status, amount, fee
) VALUES
('2025-07-01 18:00:00', 2, '2025-07-01 18:00:00', 3, 29, 1, 16, '2025-07-01 10:00:00', '2025-07-01 18:00:00', 'CONFIRMED', 'ACTIVE', 1000.00, 100.00),
('2025-07-01 18:00:00', 2, '2025-07-02 18:00:00', 3, 29, 1, 17, '2025-07-02 10:00:00', '2025-07-01 18:00:00', 'CONFIRMED', 'ACTIVE', 1000.00, 100.00),
('2025-07-01 18:00:00', 2, '2025-07-03 18:00:00', 3, 29, 1, 18, '2025-07-03 10:00:00', '2025-07-01 18:00:00', 'COMPLETED', 'ACTIVE', 1000.00, 100.00),
('2025-07-01 18:00:00', 3, '2025-07-04 18:00:00', 2, 28, 1, 19, '2025-07-04 10:00:00', '2025-07-01 18:00:00', 'CONFIRMED', 'ACTIVE', 1000.00, 100.00),
('2025-07-01 18:00:00', 3, '2025-07-05 18:00:00', 2, 28, 1, 20, '2025-07-05 10:00:00', '2025-07-01 18:00:00', 'COMPLETED', 'ACTIVE', 1000.00, 100.00);

```

!!! 테스트 위해서 레디스 TTL 1분으로 설정하는 코드 넣기 / 스케줄러 30초마다 실행
ReservationAlarmaCacheServiceImpl 에 -> private static final long EXPIRE_SECONDS = 24 * 60 * 60; 이거 빼고 private static final long EXPIRE_SECONDS =  60; 넣기

AlertScheduledTask에 ->  @Scheduled(initialDelay = 10000, fixedRate = 1000 *30) //30초마다 실행 (테스트용) 이걸로 넣어서 하기


<알림이 온 모습>

<img width="370" height="647" alt="{7C1CA6BA-F243-4241-8EB9-421FEF8F44A7}" src="https://github.com/user-attachments/assets/f608f948-f1e3-4ae8-b071-f2dfa1d19f62" />


