### PR TITLE
fix : 멱등키 생성 방식 변경

### DIFF
--- a/airbng-consumer/src/main/java/com/airbng/consumer/service/ReservationServiceImpl.java
+++ b/airbng-consumer/src/main/java/com/airbng/consumer/service/ReservationServiceImpl.java
@@ -170,7 +170,7 @@ public class ReservationServiceImpl implements ReservationService {
             }
 
             // 환불 요청
-            UUID idemKey = UUIDUtil.generate();
+            UUID idemKey = UUIDUtil.generateFromString(reservation.getPaymentId() + ":refund");
             Long refundId = refundApi.requestRefund(
                     RefundRequestCommand.builder()
                             .reservationId(reservation.getReservationId())

--- a/airbng-consumer/src/main/java/com/airbng/consumer/service/ReservationServiceImpl.java
+++ b/airbng-consumer/src/main/java/com/airbng/consumer/service/ReservationServiceImpl.java
@@ -170,7 +170,7 @@ public class ReservationServiceImpl implements ReservationService {
             }
 
             // 환불 요청
-            UUID idemKey = UUIDUtil.generateFromString(reservation.getPaymentId() + ":refund");
+            UUID idemKey = UUIDUtil.generateFromString("refund:"+refundType.name()+":"+reservation.getReservationId());
             Long refundId = refundApi.requestRefund(
                     RefundRequestCommand.builder()
                             .reservationId(reservation.getReservationId())

--- a/airbng-platform/src/main/java/com/airbng/platform/util/UUIDUtil.java
+++ b/airbng-platform/src/main/java/com/airbng/platform/util/UUIDUtil.java
@@ -11,6 +11,13 @@ public final class UUIDUtil {
         return UUID.randomUUID(); // 기본 v4
     }
 
+    public static UUID generateFromString(String name) {
+        if (name == null || name.isBlank()) {
+            throw new IllegalArgumentException("UUID name is required");
+        }
+        return UUID.nameUUIDFromBytes(name.trim().getBytes());
+    }
+
     /**
      * 문자열을 UUID v4 객체로 변환 (형식/버전 틀리면 IllegalArgumentException)
      */

--- a/airbng-platform/src/main/java/com/airbng/platform/util/UUIDUtil.java
+++ b/airbng-platform/src/main/java/com/airbng/platform/util/UUIDUtil.java
@@ -1,5 +1,6 @@
 package com.airbng.platform.util;
 
+import java.nio.charset.StandardCharsets;
 import java.util.UUID;
 
 public final class UUIDUtil {
@@ -15,7 +16,7 @@ public final class UUIDUtil {
         if (name == null || name.isBlank()) {
             throw new IllegalArgumentException("UUID name is required");
         }
-        return UUID.nameUUIDFromBytes(name.trim().getBytes());
+        return UUID.nameUUIDFromBytes(name.trim().getBytes(StandardCharsets.UTF_8));
     }
 
     /**


### PR DESCRIPTION
## 요약 (Summary)
- [x] 환불 멱등키 생성 방식을 랜덤 → 결정적 방식으로 변경

## 🔑 변경 사항 (Key Changes)
- 기존 구현에서는 환불 요청 시 서버에서 랜덤 UUID를 생성하여 `biz_key`로 사용했습니다.
- 이 경우 동일한 결제 건에 대해 중복 요청이 발생하면 매번 새로운 UUID가 발급되어 멱등성이 제대로 보장되지 않는 문제가 있었습니다.
   - 랜덤 UUID 방식은 **프론트엔드에서 요청 단위 멱등성 보장**을 위해 적합하지만, 서버 내부에서는 **결제 건 단위로 항상 동일한 키**를 생성할 필요가 있습니다.
- 따라서 환불 멱등키(`biz_key`) 생성 방식을 **결제 건에 종속된 UUID** 방식으로 교체했습니다.

=> 그냥 paymentId에 UNIQUE 걸면 되지 않나?
- 현재의 환불은 전액/부분 중 ‘하나만’ 발생하는 구조지만, “하나의 짐 타입만 부분 취소” 등 부분 환불 확장을 고려하고 있어, `payment_id`에 단일 UNIQUE를 걸면 정책 확장 시 제약을 다시 뜯어고쳐야 한다는 문제가 있습니다.
- 따라서 확장성을 고려했을 때 해당 방식이 적합하다고 판단했습니다.
